### PR TITLE
Extend CI with Postman tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,22 @@ jobs:
             sleep 5
           done
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Newman
+        run: npm install -g newman
+
+      - name: Prepare Postman collection
+        env:
+          MAXIRMX_SECRET_PASSWORD: ${{ secrets.MAXIRMX_SECRET_PASSWORD }}
+        run: sed -i "s/MAXIRMX_SECRET_PASSWORD/$MAXIRMX_SECRET_PASSWORD/g" tests/postman.json
+
+      - name: Run Postman tests
+        run: newman run tests/postman.json
+
       - name: Stop services
         if: always()
         run: docker compose -f docker-compose.yml down


### PR DESCRIPTION
## Summary
- extend CI workflow with postman tests using newman
- substitute `MAXIRMX_SECRET_PASSWORD` placeholder using repository secret

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685592e006a88321bfdc95ad515a2f6e