### PR TITLE
Add NUnit tests and integrate with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run unit tests
+        run: dotnet test Logibooks.sln --no-build --verbosity normal
+
       - name: Build Docker images
         run: docker compose -f docker-compose.yml build
 

--- a/Logibooks.sln
+++ b/Logibooks.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.33424.131
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logibooks.Core", "Logibooks.Core\Logibooks.Core.csproj", "{C8D48598-6D6D-43F7-89C6-5F56D91D2593}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logibooks.Core.Tests", "tests\Logibooks.Core.Tests\Logibooks.Core.Tests.csproj", "{55E5DDE3-21EB-462F-B1F3-9A2A89814E12}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		tests\postman.json = tests\postman.json
@@ -20,8 +22,12 @@ Global
 		{C8D48598-6D6D-43F7-89C6-5F56D91D2593}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C8D48598-6D6D-43F7-89C6-5F56D91D2593}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8D48598-6D6D-43F7-89C6-5F56D91D2593}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C8D48598-6D6D-43F7-89C6-5F56D91D2593}.Release|Any CPU.Build.0 = Release|Any CPU
-		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C8D48598-6D6D-43F7-89C6-5F56D91D2593}.Release|Any CPU.Build.0 = Release|Any CPU
+                {55E5DDE3-21EB-462F-B1F3-9A2A89814E12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {55E5DDE3-21EB-462F-B1F3-9A2A89814E12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {55E5DDE3-21EB-462F-B1F3-9A2A89814E12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {55E5DDE3-21EB-462F-B1F3-9A2A89814E12}.Release|Any CPU.Build.0 = Release|Any CPU
+                {81DDED9D-158B-E303-5F62-77A2896D2A5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81DDED9D-158B-E303-5F62-77A2896D2A5A}.Release|Any CPU.Build.0 = Release|Any CPU

--- a/tests/Logibooks.Core.Tests/Data/AppDbContextTests.cs
+++ b/tests/Logibooks.Core.Tests/Data/AppDbContextTests.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+using Microsoft.EntityFrameworkCore;
+using Logibooks.Core.Data;
+
+namespace Logibooks.Core.Tests.Data;
+
+public class AppDbContextTests
+{
+    private AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase("test_db")
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Test]
+    public void CheckSameUser_ReturnsTrue_WhenIdsMatch()
+    {
+        using var ctx = CreateContext();
+        Assert.True(ctx.CheckSameUser(1, 1));
+    }
+
+    [Test]
+    public void CheckSameUser_ReturnsFalse_WhenIdsDiffer()
+    {
+        using var ctx = CreateContext();
+        Assert.False(ctx.CheckSameUser(1, 2));
+    }
+
+    [Test]
+    public void CheckSameUser_ReturnsFalse_WhenCuidZero()
+    {
+        using var ctx = CreateContext();
+        Assert.False(ctx.CheckSameUser(1, 0));
+    }
+}

--- a/tests/Logibooks.Core.Tests/Logibooks.Core.Tests.csproj
+++ b/tests/Logibooks.Core.Tests/Logibooks.Core.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Logibooks.Core\Logibooks.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Logibooks.Core.Tests/Models/UserTests.cs
+++ b/tests/Logibooks.Core.Tests/Models/UserTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.Tests.Models;
+
+public class UserTests
+{
+    [Test]
+    public void HasAnyRole_ReturnsFalse_WhenNoRoles()
+    {
+        var user = new User();
+        Assert.False(user.HasAnyRole());
+    }
+
+    [Test]
+    public void HasAnyRole_ReturnsTrue_WhenRolesExist()
+    {
+        var role = new Role { Id = 1, Name = "admin", Title = "Admin" };
+        var user = new User { UserRoles = new List<UserRole> { new UserRole { Role = role } } };
+        Assert.True(user.HasAnyRole());
+    }
+
+    [Test]
+    public void HasRole_IgnoresCase()
+    {
+        var role = new Role { Id = 1, Name = "Admin", Title = "Admin" };
+        var user = new User { UserRoles = new List<UserRole> { new UserRole { Role = role } } };
+        Assert.True(user.HasRole("admin"));
+    }
+
+    [Test]
+    public void HasRole_ReturnsFalse_WhenRoleMissing()
+    {
+        var user = new User();
+        Assert.False(user.HasRole("admin"));
+    }
+
+    [Test]
+    public void IsAdministrator_ReturnsTrue_WhenAdminRolePresent()
+    {
+        var role = new Role { Id = 2, Name = "administrator", Title = "Administrator" };
+        var user = new User { UserRoles = new List<UserRole> { new UserRole { Role = role } } };
+        Assert.True(user.IsAdministrator());
+    }
+}


### PR DESCRIPTION
## Summary
- add NUnit test project for `Logibooks.Core`
- cover `User` logic and `AppDbContext.CheckSameUser`
- include test project in solution
- run `dotnet test` in CI workflow

## Testing
- `dotnet test Logibooks.sln --no-build --verbosity normal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68571d8fc7d883218e96623e0d8b8cf6