### PR TITLE
Add Codecov upload and badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,13 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Run unit tests
-        run: dotnet test Logibooks.sln --no-build --verbosity normal
+      - name: Run unit tests with coverage
+        run: dotnet test Logibooks.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build Docker images
         run: docker compose -f docker-compose.yml build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 
 # Logibooks Core
 
+[![CI](https://github.com/maxirmx/logibooks.core/actions/workflows/ci.yml/badge.svg)](https://github.com/maxirmx/logibooks.core/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/maxirmx/logibooks.core/branch/main/graph/badge.svg)](https://codecov.io/gh/maxirmx/logibooks.core)
+
 This is the core backend service for the Logibooks logistics system. It provides a RESTful API over a PostgreSQL database using Entity Framework Core.
 
 ## Technologies


### PR DESCRIPTION
## Summary
- add CI and codecov badges to README
- collect coverage in CI and upload to Codecov

## Testing
- `dotnet test Logibooks.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685720ecac1c8321be00c2c43f498bba