### PR TITLE
feat: add version info to status API

### DIFF
--- a/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
@@ -31,6 +31,7 @@ using Logibooks.Core.Controllers;
 using Logibooks.Core.Data;
 using Logibooks.Core.RestModels;
 using Logibooks.Core;
+using System.Threading.Tasks;
 
 namespace Logibooks.Core.Tests.Controllers;
 
@@ -64,14 +65,19 @@ public class StatusControllerTests
     [Test]
     public async Task Status_ReturnsVersionInformation()
     {
+        // Act
         var result = await _controller.Status();
 
+        // Assert
         Assert.That(result.Result, Is.TypeOf<Microsoft.AspNetCore.Mvc.OkObjectResult>());
-        Assert.That(result.Value, Is.Not.Null);
+        var okResult = result.Result as Microsoft.AspNetCore.Mvc.OkObjectResult;
+        Assert.That(okResult, Is.Not.Null);
 
-        var status = result.Value!;
-        Assert.That(status.Msg, Does.Contain("Logibooks Core"));
+        var status = okResult!.Value as Status;
+        Assert.That(status, Is.Not.Null);
+
+        Assert.That(status!.Msg, Does.Contain("Logibooks Core"));
         Assert.That(status.AppVersion, Is.EqualTo(VersionInfo.AppVersion));
-        Assert.That(status.DbVersion, Is.EqualTo(VersionInfo.DbVersion));
+        Assert.That(status.DbVersion, Is.Not.Null.And.Not.Empty);
     }
 }

--- a/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks core applcation
+// This file is a part of Logibooks core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks core applcation
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+
+using Logibooks.Core.Controllers;
+using Logibooks.Core.Data;
+using Logibooks.Core.RestModels;
+using Logibooks.Core;
+
+namespace Logibooks.Core.Tests.Controllers;
+
+[TestFixture]
+public class StatusControllerTests
+{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+    private AppDbContext _dbContext;
+    private StatusController _controller;
+    private ILogger<StatusController> _logger;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: $"status_controller_test_db_{System.Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+        _logger = new LoggerFactory().CreateLogger<StatusController>();
+        _controller = new StatusController(_dbContext, _logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    [Test]
+    public async Task Status_ReturnsVersionInformation()
+    {
+        var result = await _controller.Status();
+
+        Assert.That(result.Result, Is.TypeOf<Microsoft.AspNetCore.Mvc.OkObjectResult>());
+        Assert.That(result.Value, Is.Not.Null);
+
+        var status = result.Value!;
+        Assert.That(status.Msg, Does.Contain("Logibooks Core"));
+        Assert.That(status.AppVersion, Is.EqualTo(VersionInfo.AppVersion));
+        Assert.That(status.DbVersion, Is.EqualTo(VersionInfo.DbVersion));
+    }
+}

--- a/Logibooks.Core.Tests/Controllers/UserControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/UserControllerTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks core applcation
+// This file is a part of Logibooks core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core.Tests/Data/AppDbContextTests.cs
+++ b/Logibooks.Core.Tests/Data/AppDbContextTests.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core.Tests/Models/UserTests.cs
+++ b/Logibooks.Core.Tests/Models/UserTests.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Authorization/AllowAnonimousAttribute.cs
+++ b/Logibooks.Core/Authorization/AllowAnonimousAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Authorization/AuthorizeAttribute.cs
+++ b/Logibooks.Core/Authorization/AuthorizeAttribute.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Authorization/JwtMiddleware.cs
+++ b/Logibooks.Core/Authorization/JwtMiddleware.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Authorization/JwtUtils.cs
+++ b/Logibooks.Core/Authorization/JwtUtils.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Controllers/StatusController.cs
+++ b/Logibooks.Core/Controllers/StatusController.cs
@@ -56,12 +56,18 @@ public class StatusController(
         {
             // Query the __EFMigrationsHistory table for the last applied migration
             var lastMigration = await _db.Database.GetAppliedMigrationsAsync();
-            dbVersion = lastMigration.LastOrDefault() ?? "No migrations found";
+            dbVersion = lastMigration.LastOrDefault() ?? "00000000000000";
+            // Truncate dbVersion up to the first '_' if present
+            if (dbVersion.Contains('_'))
+            {
+                dbVersion = dbVersion[..dbVersion.IndexOf('_')];
+            }
+
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error retrieving migration history");
-            dbVersion = "Error retrieving migration history";
+            dbVersion = "00000000000000";
         }
 
         Status status = new()

--- a/Logibooks.Core/Controllers/StatusController.cs
+++ b/Logibooks.Core/Controllers/StatusController.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Controllers/StatusController.cs
+++ b/Logibooks.Core/Controllers/StatusController.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (C) 2023 Maxim [maxirmx] Samsonov (www.sw.consulting)
+﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of TrustVPN applcation
+// This file is a part of Logibooks Core applcation
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Controllers/StatusController.cs
+++ b/Logibooks.Core/Controllers/StatusController.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Mvc;
 using Logibooks.Core.Authorization;
 using Logibooks.Core.Data;
 using Logibooks.Core.RestModels;
+using Logibooks.Core;
 
 namespace Logibooks.Core.Controllers;
 
@@ -48,9 +49,11 @@ public class StatusController(
     {
         _logger.LogDebug("Check service status");
 
-        Status status = new() 
+        Status status = new()
         {
             Msg = "Hello, world! Logibooks Core status is fantastic!",
+            AppVersion = VersionInfo.AppVersion,
+            DbVersion = VersionInfo.DbVersion,
         };
         _logger.LogDebug("Check service status returning:\n{status}", status);
 

--- a/Logibooks.Core/Controllers/UsersController.cs
+++ b/Logibooks.Core/Controllers/UsersController.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/RestModels/Credentials.cs
+++ b/Logibooks.Core/RestModels/Credentials.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/RestModels/ErrMessage.cs
+++ b/Logibooks.Core/RestModels/ErrMessage.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/RestModels/Status.cs
+++ b/Logibooks.Core/RestModels/Status.cs
@@ -30,8 +30,4 @@ public class Status
     public required string AppVersion { get; set; }
     public required string DbVersion { get; set; }
 
-    public override string ToString()
-    {
-        return $"{Msg} (app={AppVersion}, db={DbVersion})";
-    }
 }

--- a/Logibooks.Core/RestModels/Status.cs
+++ b/Logibooks.Core/RestModels/Status.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/RestModels/Status.cs
+++ b/Logibooks.Core/RestModels/Status.cs
@@ -27,8 +27,11 @@ namespace Logibooks.Core.RestModels;
 public class Status
 {
     public required string Msg { get; set; }
+    public required string AppVersion { get; set; }
+    public required string DbVersion { get; set; }
+
     public override string ToString()
     {
-        return Msg;
+        return $"{Msg} (app={AppVersion}, db={DbVersion})";
     }
 }

--- a/Logibooks.Core/RestModels/UserUpdateItem.cs
+++ b/Logibooks.Core/RestModels/UserUpdateItem.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/RestModels/UserViewItem.cs
+++ b/Logibooks.Core/RestModels/UserViewItem.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/RestModels/UserViewItemWithJwt.cs
+++ b/Logibooks.Core/RestModels/UserViewItemWithJwt.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/Settings/JOptions.cs
+++ b/Logibooks.Core/Settings/JOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core applcation
+// This file is a part of Logibooks Core application
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/Logibooks.Core/VersionInfo.cs
+++ b/Logibooks.Core/VersionInfo.cs
@@ -1,13 +1,10 @@
 namespace Logibooks.Core;
 
 /// <summary>
-/// Provides build and database version information.
+/// Provides application version information.
 /// </summary>
 public static class VersionInfo
 {
     /// <summary>Application version.</summary>
-    public const string AppVersion = "1.0.0";
-
-    /// <summary>Database schema version (latest migration timestamp).</summary>
-    public const string DbVersion = "20250621141410";
+    public const string AppVersion = "0.1.0";
 }

--- a/Logibooks.Core/VersionInfo.cs
+++ b/Logibooks.Core/VersionInfo.cs
@@ -1,0 +1,13 @@
+namespace Logibooks.Core;
+
+/// <summary>
+/// Provides build and database version information.
+/// </summary>
+public static class VersionInfo
+{
+    /// <summary>Application version.</summary>
+    public const string AppVersion = "1.0.0";
+
+    /// <summary>Database schema version (latest migration timestamp).</summary>
+    public const string DbVersion = "20250621141410";
+}


### PR DESCRIPTION
## Summary
- add `VersionInfo` class for app/db version constants
- return app and database version from `StatusController`
- extend `Status` model with version fields
- cover new functionality in `StatusControllerTests`

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857d8fe14388321a7bd6f1e2ae0f477