### PR TITLE
Add register deletion endpoint

### DIFF
--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -62,22 +62,17 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
     protected ObjectResult _403()
     {
         return StatusCode(StatusCodes.Status403Forbidden,
-                          new ErrMessage { Msg = "Недостаточно прав для выполнения операции." });
+                          new ErrMessage { Msg = "Недостаточно прав для выполнения операции" });
     }
     protected ObjectResult _404User(int id)
     {
         return StatusCode(StatusCodes.Status404NotFound,
-                          new ErrMessage { Msg = $"Не удалось найти пользователя [id={id}]." });
-    }
-    protected ObjectResult _404Profile(int id)
-    {
-        return StatusCode(StatusCodes.Status404NotFound,
-                          new ErrMessage { Msg = $"Не удалось найти профиль [profile id={id}]." });
+                          new ErrMessage { Msg = $"Не удалось найти пользователя [id={id}]" });
     }
     protected ObjectResult _404Register(int id)
     {
         return StatusCode(StatusCodes.Status404NotFound,
-                          new ErrMessage { Msg = $"Не удалось найти реестр [id={id}]." });
+                          new ErrMessage { Msg = $"Не удалось найти реестр [id={id}]" });
     }
     protected ObjectResult _409Email(string email)
     {

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -74,6 +74,11 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
         return StatusCode(StatusCodes.Status404NotFound,
                           new ErrMessage { Msg = $"Не удалось найти профиль [profile id={id}]." });
     }
+    protected ObjectResult _404Register(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти реестр [id={id}]." });
+    }
     protected ObjectResult _409Email(string email)
     {
         return StatusCode(StatusCodes.Status409Conflict,

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -170,7 +170,6 @@ public class RegistersController(
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
-    [ProducesResponseType(StatusCodes.Status418ImATeapot, Type = typeof(ErrMessage))]
     public async Task<IActionResult> DeleteRegister(int id)
     {
         _logger.LogDebug("DeleteRegister for id={id}", id);

--- a/Logibooks.Core/Controllers/UsersController.cs
+++ b/Logibooks.Core/Controllers/UsersController.cs
@@ -101,7 +101,6 @@ public class UsersController(
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
-    [ProducesResponseType(StatusCodes.Status418ImATeapot, Type = typeof(ErrMessage))]
     public async Task<ActionResult<Reference>> PostUser(UserCreateItem user)
     {
         _logger.LogDebug("PostUser (create) for {user}", user.ToString());


### PR DESCRIPTION
## Summary
- add API endpoint to delete registers with cascading orders
- implement `_404Register` error response
- unit test register deletion scenarios

## Testing
- `dotnet test Logibooks.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6863d59ecbbc8321b69ffa9df5872d58