### PR TITLE
Add order counts to register view

### DIFF
--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -131,6 +131,33 @@ public class RegistersControllerTests
         Assert.That(result.Value, Is.Not.Null);
         Assert.That(result.Value!.Id, Is.EqualTo(1));
         Assert.That(result.Value.FileName, Is.EqualTo("reg.xlsx"));
+        Assert.That(result.Value.OrdersTotal, Is.EqualTo(0));
+        Assert.That(result.Value.OrdersByStatus.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetRegister_ReturnsOrderCounts()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Statuses.AddRange(
+            new OrderStatus { Id = 1, Name = "loaded", Title = "Loaded" },
+            new OrderStatus { Id = 2, Name = "processed", Title = "Processed" }
+        );
+        var register = new Register { Id = 1, FileName = "reg.xlsx" };
+        _dbContext.Registers.Add(register);
+        _dbContext.Orders.AddRange(
+            new Order { Id = 1, RegisterId = 1, StatusId = 1 },
+            new Order { Id = 2, RegisterId = 1, StatusId = 2 },
+            new Order { Id = 3, RegisterId = 1, StatusId = 1 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetRegister(1);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.OrdersTotal, Is.EqualTo(3));
+        Assert.That(result.Value.OrdersByStatus[1], Is.EqualTo(2));
+        Assert.That(result.Value.OrdersByStatus[2], Is.EqualTo(1));
     }
 
     [Test]

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -48,10 +48,10 @@ public class RegistersController(
     ILogger<RegistersController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
     [HttpGet("{id}")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Register))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RegisterViewItem))]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
-    public async Task<ActionResult<Register>> GetRegister(int id)
+    public async Task<ActionResult<RegisterViewItem>> GetRegister(int id)
     {
         _logger.LogDebug("GetRegister for id={id}", id);
 
@@ -73,8 +73,22 @@ public class RegistersController(
             return _404Register(id);
         }
 
+        var statusCounts = register.Orders
+            .GroupBy(o => o.StatusId)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var view = new RegisterViewItem
+        {
+            Id = register.Id,
+            FileName = register.FileName,
+            Date = register.DTime,
+            Orders = register.Orders.ToList(),
+            OrdersTotal = register.Orders.Count,
+            OrdersByStatus = statusCounts
+        };
+
         _logger.LogDebug("GetRegister returning register with {count} orders", register.Orders.Count);
-        return register;
+        return view;
     }
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<RegisterItem>))]

--- a/Logibooks.Core/RestModels/RegisterViewItem.cs
+++ b/Logibooks.Core/RestModels/RegisterViewItem.cs
@@ -1,0 +1,12 @@
+using Logibooks.Core.Models;
+namespace Logibooks.Core.RestModels;
+
+public class RegisterViewItem
+{
+    public int Id { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public DateTime Date { get; set; }
+    public List<Order> Orders { get; set; } = [];
+    public int OrdersTotal { get; set; }
+    public Dictionary<int, int> OrdersByStatus { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- add new `RegisterViewItem` DTO
- extend `GetRegister` to return total orders and per-status counts
- test new behaviour in controller tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640cf1af5883218285447d490bfa37