### PR TITLE
Refactor register order stats

### DIFF
--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -140,6 +140,28 @@ public class RegistersControllerTests
     }
 
     [Test]
+    public async Task GetRegisters_ReturnsZeroOrders_WhenNoOrders()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Registers.AddRange(
+            new Register { Id = 1, FileName = "r1.xlsx" },
+            new Register { Id = 2, FileName = "r2.xlsx" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetRegisters();
+        var ok = result.Result as OkObjectResult;
+        var items = (ok!.Value as IEnumerable<RegisterViewItem>)!
+            .OrderBy(i => i.Id).ToArray();
+
+        Assert.That(items.Length, Is.EqualTo(2));
+        Assert.That(items[0].OrdersTotal, Is.EqualTo(0));
+        Assert.That(items[0].OrdersByStatus.Count, Is.EqualTo(0));
+        Assert.That(items[1].OrdersTotal, Is.EqualTo(0));
+        Assert.That(items[1].OrdersByStatus.Count, Is.EqualTo(0));
+    }
+
+    [Test]
     public async Task GetRegisters_ReturnsForbidden_ForNonLogist()
     {
         SetCurrentUserId(2);
@@ -189,6 +211,34 @@ public class RegistersControllerTests
         Assert.That(result.Value!.OrdersTotal, Is.EqualTo(3));
         Assert.That(result.Value.OrdersByStatus[1], Is.EqualTo(2));
         Assert.That(result.Value.OrdersByStatus[2], Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetRegister_ReturnsOrderCounts_WithMultipleStatusGroups()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Statuses.AddRange(
+            new OrderStatus { Id = 1, Name = "loaded", Title = "Loaded" },
+            new OrderStatus { Id = 2, Name = "processed", Title = "Processed" },
+            new OrderStatus { Id = 3, Name = "delivered", Title = "Delivered" }
+        );
+        var register = new Register { Id = 1, FileName = "reg.xlsx" };
+        _dbContext.Registers.Add(register);
+        _dbContext.Orders.AddRange(
+            new Order { Id = 1, RegisterId = 1, StatusId = 1 },
+            new Order { Id = 2, RegisterId = 1, StatusId = 2 },
+            new Order { Id = 3, RegisterId = 1, StatusId = 3 },
+            new Order { Id = 4, RegisterId = 1, StatusId = 3 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetRegister(1);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.OrdersTotal, Is.EqualTo(4));
+        Assert.That(result.Value.OrdersByStatus[1], Is.EqualTo(1));
+        Assert.That(result.Value.OrdersByStatus[2], Is.EqualTo(1));
+        Assert.That(result.Value.OrdersByStatus[3], Is.EqualTo(2));
     }
 
     [Test]

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -74,12 +74,8 @@ public class RegistersController(
             return _404Register(id);
         }
 
-        var ordersByStatus = await _db.Orders
-            .AsNoTracking()
-            .Where(o => o.RegisterId == id)
-            .GroupBy(o => o.StatusId)
-            .Select(g => new { StatusId = g.Key, Count = g.Count() })
-            .ToDictionaryAsync(g => g.StatusId, g => g.Count);
+        var ordersStats = await FetchOrdersStats([id]);
+        var ordersByStatus = ordersStats.GetValueOrDefault(id, new Dictionary<int, int>());
 
         var view = new RegisterViewItem
         {
@@ -122,20 +118,20 @@ public class RegistersController(
             .ToListAsync();
 
         var ids = items.Select(i => i.Id).ToList();
-        var stats = await _db.Orders
-            .AsNoTracking()
-            .Where(o => ids.Contains(o.RegisterId))
-            .Select(o => new { o.RegisterId, o.StatusId })
-            .ToListAsync();
+        var stats = await FetchOrdersStats(ids);
 
         foreach (var item in items)
         {
-            var byStatus = stats
-                .Where(s => s.RegisterId == item.Id)
-                .GroupBy(s => s.StatusId)
-                .ToDictionary(g => g.Key, g => g.Count());
-            item.OrdersByStatus = byStatus;
-            item.OrdersTotal = byStatus.Values.Sum();
+            if (stats.TryGetValue(item.Id, out var byStatus))
+            {
+                item.OrdersByStatus = byStatus;
+                item.OrdersTotal = byStatus.Values.Sum();
+            }
+            else
+            {
+                item.OrdersByStatus = new();
+                item.OrdersTotal = 0;
+            }
         }
 
         _logger.LogDebug("GetRegisters returning count: {count} items", items.Count);
@@ -258,8 +254,24 @@ public class RegistersController(
         return NoContent();
     }
 
+    private async Task<Dictionary<int, Dictionary<int, int>>> FetchOrdersStats(IEnumerable<int> registerIds)
+    {
+        var grouped = await _db.Orders
+            .AsNoTracking()
+            .Where(o => registerIds.Contains(o.RegisterId))
+            .GroupBy(o => new { o.RegisterId, o.StatusId })
+            .Select(g => new { g.Key.RegisterId, g.Key.StatusId, Count = g.Count() })
+            .ToListAsync();
+
+        return grouped
+            .GroupBy(g => g.RegisterId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.ToDictionary(x => x.StatusId, x => x.Count));
+    }
+
     private async Task<IActionResult> ProcessExcel(
-        byte[] content, 
+        byte[] content,
         string fileName, 
         string mappingFile = "register_mapping.yaml")
     {

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -122,16 +122,9 @@ public class RegistersController(
 
         foreach (var item in items)
         {
-            if (stats.TryGetValue(item.Id, out var byStatus))
-            {
-                item.OrdersByStatus = byStatus;
-                item.OrdersTotal = byStatus.Values.Sum();
-            }
-            else
-            {
-                item.OrdersByStatus = new();
-                item.OrdersTotal = 0;
-            }
+            var byStatus = stats.GetValueOrDefault(item.Id, new Dictionary<int, int>());
+            item.OrdersByStatus = byStatus;
+            item.OrdersTotal = byStatus.Values.Sum();
         }
 
         _logger.LogDebug("GetRegisters returning count: {count} items", items.Count);


### PR DESCRIPTION
## Summary
- DRY order counting with FetchOrdersStats helper
- use database grouping in GetRegister and GetRegisters
- add tests for no orders and multi-status scenarios

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866505b72388321a630e66d1ccdd3bb