### PR TITLE
Add sorting and search to registers API

### DIFF
--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -230,6 +230,39 @@ public class RegistersControllerTests
     }
 
     [Test]
+    public async Task GetRegisters_SortsByOrdersTotalAcrossPages()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Registers.AddRange(
+            new Register { Id = 1, FileName = "r1.xlsx" },
+            new Register { Id = 2, FileName = "r2.xlsx" },
+            new Register { Id = 3, FileName = "r3.xlsx" },
+            new Register { Id = 4, FileName = "r4.xlsx" }
+        );
+        _dbContext.Orders.AddRange(
+            new Order { RegisterId = 1, StatusId = 1 },
+            new Order { RegisterId = 2, StatusId = 1 },
+            new Order { RegisterId = 2, StatusId = 1 },
+            new Order { RegisterId = 3, StatusId = 1 },
+            new Order { RegisterId = 3, StatusId = 1 },
+            new Order { RegisterId = 3, StatusId = 1 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var r1 = await _controller.GetRegisters(page: 1, pageSize: 2, sortBy: "ordersTotal", sortOrder: "desc");
+        var ok1 = r1.Result as OkObjectResult;
+        var pr1 = ok1!.Value as PagedResult<RegisterViewItem>;
+
+        Assert.That(pr1!.Items.First().Id, Is.EqualTo(3));
+
+        var r2 = await _controller.GetRegisters(page: 2, pageSize: 2, sortBy: "ordersTotal", sortOrder: "desc");
+        var ok2 = r2.Result as OkObjectResult;
+        var pr2 = ok2!.Value as PagedResult<RegisterViewItem>;
+
+        Assert.That(pr2!.Items.First().Id, Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task GetRegister_ReturnsRegister_ForLogist()
     {
         SetCurrentUserId(1);

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -209,6 +209,27 @@ public class RegistersControllerTests
     }
 
     [Test]
+    public async Task GetRegisters_ReturnsPaginationMetadata()
+    {
+        SetCurrentUserId(1);
+        for (int i = 1; i <= 25; i++)
+        {
+            _dbContext.Registers.Add(new Register { Id = i, FileName = $"r{i}.xlsx" });
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetRegisters(page: 2, pageSize: 10);
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<RegisterViewItem>;
+
+        Assert.That(pr!.Items.Count(), Is.EqualTo(10));
+        Assert.That(pr.Pagination.TotalCount, Is.EqualTo(25));
+        Assert.That(pr.Pagination.TotalPages, Is.EqualTo(3));
+        Assert.That(pr.Pagination.HasNextPage, Is.True);
+        Assert.That(pr.Pagination.HasPreviousPage, Is.True);
+    }
+
+    [Test]
     public async Task GetRegister_ReturnsRegister_ForLogist()
     {
         SetCurrentUserId(1);

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -168,21 +168,21 @@ public class RegistersController(
                 r.FileName.Contains(q, StringComparison.OrdinalIgnoreCase) ||
                 r.Date.ToString("s").Contains(q, StringComparison.OrdinalIgnoreCase) ||
                 r.OrdersTotal.ToString().Contains(q, StringComparison.OrdinalIgnoreCase))
-                ;
+                .ToList();
         }
 
         // Sorting
         regs = (sortBy.ToLower(), sortOrder) switch
         {
-            ("filename", "asc") => regs.OrderBy(r => r.FileName),
-            ("filename", "desc") => regs.OrderByDescending(r => r.FileName),
-            ("date", "asc") => regs.OrderBy(r => r.Date),
-            ("date", "desc") => regs.OrderByDescending(r => r.Date),
-            ("orderstotal", "asc") => regs.OrderBy(r => r.OrdersTotal),
-            ("orderstotal", "desc") => regs.OrderByDescending(r => r.OrdersTotal),
-            ("id", "desc") => regs.OrderByDescending(r => r.Id),
-            _ => regs.OrderBy(r => r.Id)
-        }.ToList();
+            ("filename", "asc") => regs.OrderBy(r => r.FileName).ToList(),
+            ("filename", "desc") => regs.OrderByDescending(r => r.FileName).ToList(),
+            ("date", "asc") => regs.OrderBy(r => r.Date).ToList(),
+            ("date", "desc") => regs.OrderByDescending(r => r.Date).ToList(),
+            ("orderstotal", "asc") => regs.OrderBy(r => r.OrdersTotal).ToList(),
+            ("orderstotal", "desc") => regs.OrderByDescending(r => r.OrdersTotal).ToList(),
+            ("id", "desc") => regs.OrderByDescending(r => r.Id).ToList(),
+            _ => regs.OrderBy(r => r.Id).ToList()
+        };
 
         var totalCount = regs.Count;
         var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -139,7 +139,7 @@ public class RegistersController(
 
         if (!string.IsNullOrWhiteSpace(search))
         {
-            baseQuery = baseQuery.Where(r => r.FileName.Contains(search, StringComparison.OrdinalIgnoreCase));
+            baseQuery = baseQuery.Where(r => EF.Functions.Like(r.FileName, $"%{search}%"));
         }
         // Project to view items with orders total included for sorting
         IQueryable<RegisterViewItem> query = baseQuery

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -132,9 +132,16 @@ public class RegistersController(
             return _403();
         }
 
-        // Load all registers
-        var regs = await _db.Registers
-            .AsNoTracking()
+        // Apply sorting and pagination at the database level
+        var query = _db.Registers.AsNoTracking();
+
+        query = sortOrder == "asc"
+            ? query.OrderBy(r => EF.Property<object>(r, sortBy))
+            : query.OrderByDescending(r => EF.Property<object>(r, sortBy));
+
+        var regs = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .Select(r => new RegisterViewItem
             {
                 Id = r.Id,

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -132,16 +132,9 @@ public class RegistersController(
             return _403();
         }
 
-        // Apply sorting and pagination at the database level
-        var query = _db.Registers.AsNoTracking();
-
-        query = sortOrder == "asc"
-            ? query.OrderBy(r => EF.Property<object>(r, sortBy))
-            : query.OrderByDescending(r => EF.Property<object>(r, sortBy));
-
-        var regs = await query
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
+        // Load all registers
+        var regs = await _db.Registers
+            .AsNoTracking()
             .Select(r => new RegisterViewItem
             {
                 Id = r.Id,

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -168,21 +168,21 @@ public class RegistersController(
                 r.FileName.Contains(q, StringComparison.OrdinalIgnoreCase) ||
                 r.Date.ToString("s").Contains(q, StringComparison.OrdinalIgnoreCase) ||
                 r.OrdersTotal.ToString().Contains(q, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+                ;
         }
 
         // Sorting
         regs = (sortBy.ToLower(), sortOrder) switch
         {
-            ("filename", "asc") => regs.OrderBy(r => r.FileName).ToList(),
-            ("filename", "desc") => regs.OrderByDescending(r => r.FileName).ToList(),
-            ("date", "asc") => regs.OrderBy(r => r.Date).ToList(),
-            ("date", "desc") => regs.OrderByDescending(r => r.Date).ToList(),
-            ("orderstotal", "asc") => regs.OrderBy(r => r.OrdersTotal).ToList(),
-            ("orderstotal", "desc") => regs.OrderByDescending(r => r.OrdersTotal).ToList(),
-            ("id", "desc") => regs.OrderByDescending(r => r.Id).ToList(),
-            _ => regs.OrderBy(r => r.Id).ToList()
-        };
+            ("filename", "asc") => regs.OrderBy(r => r.FileName),
+            ("filename", "desc") => regs.OrderByDescending(r => r.FileName),
+            ("date", "asc") => regs.OrderBy(r => r.Date),
+            ("date", "desc") => regs.OrderByDescending(r => r.Date),
+            ("orderstotal", "asc") => regs.OrderBy(r => r.OrdersTotal),
+            ("orderstotal", "desc") => regs.OrderByDescending(r => r.OrdersTotal),
+            ("id", "desc") => regs.OrderByDescending(r => r.Id),
+            _ => regs.OrderBy(r => r.Id)
+        }.ToList();
 
         var totalCount = regs.Count;
         var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);

--- a/Logibooks.Core/RestModels/PagedResult.cs
+++ b/Logibooks.Core/RestModels/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace Logibooks.Core.RestModels;
+
+public class PagedResult<T>
+{
+    public IEnumerable<T> Items { get; set; } = Array.Empty<T>();
+    public PaginationInfo Pagination { get; set; } = new();
+    public SortingInfo Sorting { get; set; } = new();
+    public string? Search { get; set; }
+}

--- a/Logibooks.Core/RestModels/PaginationInfo.cs
+++ b/Logibooks.Core/RestModels/PaginationInfo.cs
@@ -1,0 +1,11 @@
+namespace Logibooks.Core.RestModels;
+
+public class PaginationInfo
+{
+    public int CurrentPage { get; set; }
+    public int PageSize { get; set; }
+    public int TotalCount { get; set; }
+    public int TotalPages { get; set; }
+    public bool HasNextPage { get; set; }
+    public bool HasPreviousPage { get; set; }
+}

--- a/Logibooks.Core/RestModels/SortingInfo.cs
+++ b/Logibooks.Core/RestModels/SortingInfo.cs
@@ -1,0 +1,7 @@
+namespace Logibooks.Core.RestModels;
+
+public class SortingInfo
+{
+    public string SortBy { get; set; } = "id";
+    public string SortOrder { get; set; } = "asc";
+}


### PR DESCRIPTION
## Summary
- add `PagedResult` helper with pagination and sorting info
- expand `GetRegisters` to support sorting and search
- provide REST models for paging helpers
- update tests for new API behaviour and add sort/search checks

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68665de413e48321b4ca699e2e059d96