### PR TITLE
Refactor Orders endpoints to use DTOs

### DIFF
--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -110,6 +110,7 @@ public class OrdersControllerTests
         var result = await _controller.GetOrder(1);
 
         Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value, Is.InstanceOf<OrderViewItem>());
         Assert.That(result.Value!.Id, Is.EqualTo(1));
     }
 
@@ -123,7 +124,7 @@ public class OrdersControllerTests
         _dbContext.Orders.Add(order);
         await _dbContext.SaveChangesAsync();
 
-        var updated = new Order { Id = 2, RegisterId = 1, StatusId = 2, TnVed = "B" };
+        var updated = new OrderUpdateItem { StatusId = 2, TnVed = "B" };
 
         var result = await _controller.UpdateOrder(2, updated);
 
@@ -149,7 +150,7 @@ public class OrdersControllerTests
 
         var result = await _controller.GetOrders(registerId: 1, statusId: 2, tnVed: "B", sortBy: "tnVed", sortOrder: "desc");
         var ok = result.Result as OkObjectResult;
-        var pr = ok!.Value as PagedResult<Order>;
+        var pr = ok!.Value as PagedResult<OrderViewItem>;
 
         Assert.That(pr!.Items.Count(), Is.EqualTo(1));
         Assert.That(pr.Items.First().Id, Is.EqualTo(3));
@@ -200,7 +201,7 @@ public class OrdersControllerTests
     public async Task UpdateOrder_ReturnsForbidden_ForNonLogist()
     {
         SetCurrentUserId(99); // unknown user
-        var updated = new Order { Id = 1 };
+        var updated = new OrderUpdateItem();
 
         var result = await _controller.UpdateOrder(1, updated);
 
@@ -217,7 +218,7 @@ public class OrdersControllerTests
         _dbContext.Registers.Add(register);
         await _dbContext.SaveChangesAsync();
 
-        var updated = new Order { Id = 1, RegisterId = 1, StatusId = 2, TnVed = "B" };
+        var updated = new OrderUpdateItem { StatusId = 2, TnVed = "B" };
 
         var result = await _controller.UpdateOrder(1, updated);
 

--- a/Logibooks.Core/RestModels/OrderUpdateItem.cs
+++ b/Logibooks.Core/RestModels/OrderUpdateItem.cs
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.Text.Json;
+using Logibooks.Core.Settings;
+
+namespace Logibooks.Core.RestModels;
+
+public class OrderUpdateItem
+{
+    public int? StatusId { get; set; }
+    public int? RowNumber { get; set; }
+    public string? OrderNumber { get; set; }
+    public string? InvoiceDate { get; set; }
+    public string? Sticker { get; set; }
+    public string? Shk { get; set; }
+    public string? StickerCode { get; set; }
+    public string? ExtId { get; set; }
+    public string? TnVed { get; set; }
+    public string? SiteArticle { get; set; }
+    public string? HeelHeight { get; set; }
+    public string? Size { get; set; }
+    public string? ProductName { get; set; }
+    public string? Description { get; set; }
+    public string? Gender { get; set; }
+    public string? Brand { get; set; }
+    public string? FabricType { get; set; }
+    public string? Composition { get; set; }
+    public string? Lining { get; set; }
+    public string? Insole { get; set; }
+    public string? Sole { get; set; }
+    public string? Country { get; set; }
+    public string? FactoryAddress { get; set; }
+    public string? Unit { get; set; }
+    public string? WeightKg { get; set; }
+    public string? Quantity { get; set; }
+    public string? UnitPrice { get; set; }
+    public string? Currency { get; set; }
+    public string? Barcode { get; set; }
+    public string? Declaration { get; set; }
+    public string? ProductLink { get; set; }
+    public string? RecipientName { get; set; }
+    public string? RecipientInn { get; set; }
+    public string? PassportNumber { get; set; }
+    public string? Pinfl { get; set; }
+    public string? RecipientAddress { get; set; }
+    public string? ContactPhone { get; set; }
+    public string? BoxNumber { get; set; }
+    public string? Supplier { get; set; }
+    public string? SupplierInn { get; set; }
+    public string? Category { get; set; }
+    public string? Subcategory { get; set; }
+    public string? PersonalData { get; set; }
+    public string? CustomsClearance { get; set; }
+    public string? DutyPayment { get; set; }
+    public string? OtherReason { get; set; }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}

--- a/Logibooks.Core/RestModels/OrderViewItem.cs
+++ b/Logibooks.Core/RestModels/OrderViewItem.cs
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System.Text.Json;
+using Logibooks.Core.Models;
+using Logibooks.Core.Settings;
+
+namespace Logibooks.Core.RestModels;
+
+public class OrderViewItem(Order order)
+{
+    public int Id { get; set; } = order.Id;
+    public int RegisterId { get; set; } = order.RegisterId;
+    public int StatusId { get; set; } = order.StatusId;
+    public int RowNumber { get; set; } = order.RowNumber;
+    public string? OrderNumber { get; set; } = order.OrderNumber;
+    public string? InvoiceDate { get; set; } = order.InvoiceDate;
+    public string? Sticker { get; set; } = order.Sticker;
+    public string? Shk { get; set; } = order.Shk;
+    public string? StickerCode { get; set; } = order.StickerCode;
+    public string? ExtId { get; set; } = order.ExtId;
+    public string? TnVed { get; set; } = order.TnVed;
+    public string? SiteArticle { get; set; } = order.SiteArticle;
+    public string? HeelHeight { get; set; } = order.HeelHeight;
+    public string? Size { get; set; } = order.Size;
+    public string? ProductName { get; set; } = order.ProductName;
+    public string? Description { get; set; } = order.Description;
+    public string? Gender { get; set; } = order.Gender;
+    public string? Brand { get; set; } = order.Brand;
+    public string? FabricType { get; set; } = order.FabricType;
+    public string? Composition { get; set; } = order.Composition;
+    public string? Lining { get; set; } = order.Lining;
+    public string? Insole { get; set; } = order.Insole;
+    public string? Sole { get; set; } = order.Sole;
+    public string? Country { get; set; } = order.Country;
+    public string? FactoryAddress { get; set; } = order.FactoryAddress;
+    public string? Unit { get; set; } = order.Unit;
+    public string? WeightKg { get; set; } = order.WeightKg;
+    public string? Quantity { get; set; } = order.Quantity;
+    public string? UnitPrice { get; set; } = order.UnitPrice;
+    public string? Currency { get; set; } = order.Currency;
+    public string? Barcode { get; set; } = order.Barcode;
+    public string? Declaration { get; set; } = order.Declaration;
+    public string? ProductLink { get; set; } = order.ProductLink;
+    public string? RecipientName { get; set; } = order.RecipientName;
+    public string? RecipientInn { get; set; } = order.RecipientInn;
+    public string? PassportNumber { get; set; } = order.PassportNumber;
+    public string? Pinfl { get; set; } = order.Pinfl;
+    public string? RecipientAddress { get; set; } = order.RecipientAddress;
+    public string? ContactPhone { get; set; } = order.ContactPhone;
+    public string? BoxNumber { get; set; } = order.BoxNumber;
+    public string? Supplier { get; set; } = order.Supplier;
+    public string? SupplierInn { get; set; } = order.SupplierInn;
+    public string? Category { get; set; } = order.Category;
+    public string? Subcategory { get; set; } = order.Subcategory;
+    public string? PersonalData { get; set; } = order.PersonalData;
+    public string? CustomsClearance { get; set; } = order.CustomsClearance;
+    public string? DutyPayment { get; set; } = order.DutyPayment;
+    public string? OtherReason { get; set; } = order.OtherReason;
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JOptions.DefaultOptions);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `OrderViewItem` and `OrderUpdateItem` REST models
- update `OrdersController` to use these DTOs for Get and Update
- adjust controller tests for new DTO usage

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68682c5a5cfc83219735cbf413f2c87f