### PR TITLE
Reset page if past end

### DIFF
--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -297,5 +297,25 @@ public class OrdersControllerTests
         Assert.That(pr.Pagination.TotalCount, Is.EqualTo(2));
         Assert.That(pr.Pagination.TotalPages, Is.EqualTo(1));
     }
+
+    [Test]
+    public async Task GetOrders_PageExceedsTotalPages_ResetsToFirstPage()
+    {
+        SetCurrentUserId(1);
+        var reg = new Register { Id = 1, FileName = "r.xlsx" };
+        _dbContext.Registers.Add(reg);
+        for (int i = 1; i <= 6; i++)
+        {
+            _dbContext.Orders.Add(new Order { Id = i, RegisterId = 1, StatusId = 1, TnVed = "A" });
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetOrders(registerId: 1, page: 3, pageSize: 5);
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<OrderViewItem>;
+        Assert.That(pr!.Pagination.CurrentPage, Is.EqualTo(1));
+        Assert.That(pr.Items.First().Id, Is.EqualTo(1));
+    }
 }
 

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -509,6 +509,24 @@ public class RegistersControllerTests
     }
 
     [Test]
+    public async Task GetRegisters_PageExceedsTotalPages_ResetsToFirstPage()
+    {
+        SetCurrentUserId(1);
+        for (int i = 1; i <= 6; i++)
+        {
+            _dbContext.Registers.Add(new Register { Id = i, FileName = $"r{i}.xlsx" });
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetRegisters(page: 3, pageSize: 5);
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<RegisterViewItem>;
+        Assert.That(pr!.Pagination.CurrentPage, Is.EqualTo(1));
+        Assert.That(pr.Items.First().Id, Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task GetRegisters_HandlesCaseInsensitiveSortBy()
     {
         SetCurrentUserId(1);

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -180,6 +180,11 @@ public class OrdersController(
 
         var totalPages = (int)Math.Ceiling(totalCount / (double)actualPageSize);
 
+        if (actualPage > totalPages && totalPages > 0)
+        {
+            actualPage = 1;
+        }
+
         var items = await query
             .Skip((actualPage - 1) * actualPageSize)
             .Take(actualPageSize)

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -171,6 +171,11 @@ public class RegistersController(
 
         var totalPages = (int)Math.Ceiling(totalCount / (double)actualPageSize);
 
+        if (actualPage > totalPages && totalPages > 0)
+        {
+            actualPage = 1;
+        }
+
         var items = await query
             .Skip((actualPage - 1) * actualPageSize)
             .Take(actualPageSize)


### PR DESCRIPTION
## Summary
- reset page to 1 in OrdersController and RegistersController when requested page is out of range
- add regression tests verifying new behaviour

## Testing
- `dotnet restore Logibooks.Core.Tests/Logibooks.Core.Tests.csproj`
- `dotnet build Logibooks.Core.Tests/Logibooks.Core.Tests.csproj -c Release`
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj -c Release --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68692ab4609c83218f856236281973e7