### PR TITLE
Implement order statuses endpoint

### DIFF
--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -320,8 +320,26 @@ public class OrdersControllerTests
     }
 
     [Test]
+    public async Task GetStatuses_ReturnsForbidden_ForNonLogist()
+    {
+        SetCurrentUserId(2);
+
+        _dbContext.Statuses.AddRange(
+            new OrderStatus { Id = 1, Name = "loaded", Title = "Loaded" },
+            new OrderStatus { Id = 2, Name = "processed", Title = "Processed" }
+        );
+        await _dbContext.SaveChangesAsync();
+        var result = await _controller.GetStatuses();
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
     public async Task GetStatuses_ReturnsAllStatuses()
     {
+        SetCurrentUserId(1);   
         _dbContext.Statuses.AddRange(
             new OrderStatus { Id = 1, Name = "loaded", Title = "Loaded" },
             new OrderStatus { Id = 2, Name = "processed", Title = "Processed" }

--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -39,6 +39,7 @@ using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
 using AutoMapper;
+using System.Collections.Generic;
 
 namespace Logibooks.Core.Tests.Controllers;
 
@@ -316,6 +317,25 @@ public class OrdersControllerTests
         var pr = ok!.Value as PagedResult<OrderViewItem>;
         Assert.That(pr!.Pagination.CurrentPage, Is.EqualTo(1));
         Assert.That(pr.Items.First().Id, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetStatuses_ReturnsAllStatuses()
+    {
+        _dbContext.Statuses.AddRange(
+            new OrderStatus { Id = 1, Name = "loaded", Title = "Loaded" },
+            new OrderStatus { Id = 2, Name = "processed", Title = "Processed" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetStatuses();
+
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var ok = result.Result as OkObjectResult;
+        var statuses = ok!.Value as IEnumerable<OrderStatus>;
+        Assert.That(statuses, Is.Not.Null);
+        Assert.That(statuses!.Count(), Is.EqualTo(2));
+        Assert.That(statuses.First().Name, Is.EqualTo("loaded"));
     }
 }
 

--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -331,15 +331,15 @@ public class OrdersControllerTests
         await _dbContext.SaveChangesAsync();
         var result = await _controller.GetStatuses();
 
-        Assert.That(result, Is.TypeOf<ObjectResult>());
-        var obj = result as ObjectResult;
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>()); // Fix: Access the Result property
+        var obj = result.Result as ObjectResult; 
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
     }
 
     [Test]
     public async Task GetStatuses_ReturnsAllStatuses()
     {
-        SetCurrentUserId(1);   
+        SetCurrentUserId(1);
         _dbContext.Statuses.AddRange(
             new OrderStatus { Id = 1, Name = "loaded", Title = "Loaded" },
             new OrderStatus { Id = 2, Name = "processed", Title = "Processed" }
@@ -348,12 +348,12 @@ public class OrdersControllerTests
 
         var result = await _controller.GetStatuses();
 
-        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
-        var ok = result.Result as OkObjectResult;
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>()); // Fix: Access the Result property
+        var ok = result.Result as OkObjectResult; 
         var statuses = ok!.Value as IEnumerable<OrderStatus>;
         Assert.That(statuses, Is.Not.Null);
         Assert.That(statuses!.Count(), Is.EqualTo(2));
-        Assert.That(statuses.First().Name, Is.EqualTo("loaded"));
+        Assert.That(statuses!.First().Name, Is.EqualTo("loaded"));
     }
 }
 

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -213,9 +213,15 @@ public class OrdersController(
 
     [HttpGet("statuses")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<OrderStatus>))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     public async Task<ActionResult<IEnumerable<OrderStatus>>> GetStatuses()
     {
-        _logger.LogDebug("GetStatuses");
+        var ok = await _db.CheckLogist(_curUserId);
+        if (!ok)
+        {
+            _logger.LogDebug("GetStatuses returning '403 Forbidden'");
+            return _403();
+        }
         var statuses = await _db.Statuses.AsNoTracking().ToListAsync();
         _logger.LogDebug("GetStatuses returning {count} items", statuses.Count);
         return Ok(statuses);

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -222,7 +222,7 @@ public class OrdersController(
             _logger.LogDebug("GetStatuses returning '403 Forbidden'");
             return _403();
         }
-        var statuses = await _db.Statuses.AsNoTracking().ToListAsync();
+        var statuses = await _db.Statuses.AsNoTracking().OrderBy(s => s.Id).ToListAsync();
         _logger.LogDebug("GetStatuses returning {count} items", statuses.Count);
         return Ok(statuses);
     }

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -210,4 +210,14 @@ public class OrdersController(
         _logger.LogDebug("GetOrders returning {count} items", items.Count);
         return Ok(result);
     }
+
+    [HttpGet("statuses")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<OrderStatus>))]
+    public async Task<ActionResult<IEnumerable<OrderStatus>>> GetStatuses()
+    {
+        _logger.LogDebug("GetStatuses");
+        var statuses = await _db.Statuses.AsNoTracking().ToListAsync();
+        _logger.LogDebug("GetStatuses returning {count} items", statuses.Count);
+        return Ok(statuses);
+    }
 }


### PR DESCRIPTION
## Summary
- add `/api/orders/statuses` endpoint returning order statuses
- test `GetStatuses` on `OrdersController`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68698d81247c8321a2431d980c5174e4