### PR TITLE
Update weight to decimal

### DIFF
--- a/Logibooks.Core.Tests/Extensions/AutoMappingTests.cs
+++ b/Logibooks.Core.Tests/Extensions/AutoMappingTests.cs
@@ -66,7 +66,18 @@ public class AutoMapperIntegrationTests
         // Assert  
         Assert.That(order.StatusId, Is.EqualTo(5));
         Assert.That(order.OrderNumber, Is.EqualTo("DI_TEST_123"));
-        Assert.That(order.Id, Is.EqualTo(1)); // Should remain unchanged  
+        Assert.That(order.Id, Is.EqualTo(1)); // Should remain unchanged
+    }
+
+    [Test]
+    public void AutoMapper_MapsWeightKgDecimal()
+    {
+        var updateItem = new OrderUpdateItem { WeightKg = 1.234m };
+        var order = new Order();
+
+        _mapper.Map(updateItem, order);
+
+        Assert.That(order.WeightKg, Is.EqualTo(1.234m));
     }
 }
 

--- a/Logibooks.Core/Migrations/20250706073017_UpdateWeightKgDecimal.Designer.cs
+++ b/Logibooks.Core/Migrations/20250706073017_UpdateWeightKgDecimal.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Logibooks.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Logibooks.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250706073017_UpdateWeightKgDecimal")]
+    partial class UpdateWeightKgDecimal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Logibooks.Core/Migrations/20250706073017_UpdateWeightKgDecimal.cs
+++ b/Logibooks.Core/Migrations/20250706073017_UpdateWeightKgDecimal.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Logibooks.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateWeightKgDecimal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "weight_kg",
+                table: "orders",
+                type: "numeric(10,3)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "weight_kg",
+                table: "orders",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(10,3)",
+                oldNullable: true);
+        }
+    }
+}

--- a/Logibooks.Core/Models/Order.cs
+++ b/Logibooks.Core/Models/Order.cs
@@ -114,8 +114,8 @@ public class Order
     [Column("unit")]
     public string? Unit { get; set; }
 
-    [Column("weight_kg")]
-    public string? WeightKg { get; set; }
+    [Column("weight_kg", TypeName = "numeric(10,3)")]
+    public decimal? WeightKg { get; set; }
 
     [Column("quantity")]
     public string? Quantity { get; set; }

--- a/Logibooks.Core/RestModels/OrderUpdateItem.cs
+++ b/Logibooks.Core/RestModels/OrderUpdateItem.cs
@@ -54,7 +54,7 @@ public class OrderUpdateItem
     public string? Country { get; set; }
     public string? FactoryAddress { get; set; }
     public string? Unit { get; set; }
-    public string? WeightKg { get; set; }
+    public decimal? WeightKg { get; set; }
     public string? Quantity { get; set; }
     public string? UnitPrice { get; set; }
     public string? Currency { get; set; }

--- a/Logibooks.Core/RestModels/OrderViewItem.cs
+++ b/Logibooks.Core/RestModels/OrderViewItem.cs
@@ -57,7 +57,7 @@ public class OrderViewItem(Order order)
     public string? Country { get; set; } = order.Country;
     public string? FactoryAddress { get; set; } = order.FactoryAddress;
     public string? Unit { get; set; } = order.Unit;
-    public string? WeightKg { get; set; } = order.WeightKg;
+    public decimal? WeightKg { get; set; } = order.WeightKg;
     public string? Quantity { get; set; } = order.Quantity;
     public string? UnitPrice { get; set; } = order.UnitPrice;
     public string? Currency { get; set; } = order.Currency;


### PR DESCRIPTION
## Summary
- store order weight as numeric type with gram precision
- expose new decimal property in Order API models
- add EF Core migration for weight type change
- add AutoMapper test for WeightKg

## Testing
- `dotnet build Logibooks.sln`
- `dotnet test Logibooks.sln`


------
https://chatgpt.com/codex/tasks/task_e_686a25003a348321a4e99ed99ba7bf60