### PR TITLE
Add Alta parser feature

### DIFF
--- a/Logibooks.Core.Tests/Services/AltaParserTests.cs
+++ b/Logibooks.Core.Tests/Services/AltaParserTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Logibooks.Core.Services;
+using NUnit.Framework;
+
+namespace Logibooks.Core.Tests.Services;
+
+public class FakeHandler : HttpMessageHandler
+{
+    private readonly string _html;
+    public FakeHandler(string html) { _html = html; }
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(_html)
+        };
+        return Task.FromResult(resp);
+    }
+}
+
+[TestFixture]
+public class AltaParserTests
+{
+    [Test]
+    public async Task ParseAsync_ParsesHtmlTables()
+    {
+        var html = @"<table>
+<tr><td>Prod1</td><td>1234 56 789 0</td><td>c1</td></tr>
+<tr><td>Prod2</td><td>1111 22 333 4, 2222 33 444 5</td><td></td></tr>
+<tr><td>Prod3</td><td>1234 11 111 1 (за исключением 9999 99 999 9)</td><td>n</td></tr>
+</table>";
+        var client = new HttpClient(new FakeHandler(html));
+        var (items, exceptions) = await AltaParser.ParseAsync(new[] { "https://test" }, client);
+        Assert.That(items.Count, Is.EqualTo(5));
+        Assert.That(exceptions.Count, Is.EqualTo(2));
+    }
+}

--- a/Logibooks.Core/Controllers/AltaController.cs
+++ b/Logibooks.Core/Controllers/AltaController.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.Services;
+
+namespace Logibooks.Core.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Produces("application/json")]
+public class AltaController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    ILogger<AltaController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
+{
+    // POST api/alta/parse
+    [HttpPost("parse")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<int>> Parse([FromBody] List<string> urls)
+    {
+        var (items, exceptions) = await AltaParser.ParseAsync(urls);
+        if (items.Any()) _db.AltaItems.AddRange(items);
+        if (exceptions.Any()) _db.AltaExceptions.AddRange(exceptions);
+        await _db.SaveChangesAsync();
+        return items.Count;
+    }
+
+    // CRUD for AltaItems
+    [HttpGet("items")]
+    public async Task<IEnumerable<AltaItem>> GetItems() =>
+        await _db.AltaItems.AsNoTracking().ToListAsync();
+
+    [HttpGet("items/{id}")]
+    public async Task<ActionResult<AltaItem>> GetItem(int id)
+    {
+        var item = await _db.AltaItems.FindAsync(id);
+        return item == null ? _404Order(id) : item; // reuse message
+    }
+
+    [HttpPost("items")]
+    public async Task<ActionResult<AltaItem>> CreateItem(AltaItem item)
+    {
+        _db.AltaItems.Add(item);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetItem), new { id = item.Id }, item);
+    }
+
+    [HttpPut("items/{id}")]
+    public async Task<IActionResult> UpdateItem(int id, AltaItem item)
+    {
+        if (id != item.Id) return BadRequest();
+        _db.Entry(item).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("items/{id}")]
+    public async Task<IActionResult> DeleteItem(int id)
+    {
+        var item = await _db.AltaItems.FindAsync(id);
+        if (item == null) return NotFound();
+        _db.AltaItems.Remove(item);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    // CRUD for AltaExceptions
+    [HttpGet("exceptions")]
+    public async Task<IEnumerable<AltaException>> GetExceptions() =>
+        await _db.AltaExceptions.AsNoTracking().ToListAsync();
+
+    [HttpGet("exceptions/{id}")]
+    public async Task<ActionResult<AltaException>> GetException(int id)
+    {
+        var item = await _db.AltaExceptions.FindAsync(id);
+        return item == null ? _404Order(id) : item; // reuse message
+    }
+
+    [HttpPost("exceptions")]
+    public async Task<ActionResult<AltaException>> CreateException(AltaException item)
+    {
+        _db.AltaExceptions.Add(item);
+        await _db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetException), new { id = item.Id }, item);
+    }
+
+    [HttpPut("exceptions/{id}")]
+    public async Task<IActionResult> UpdateException(int id, AltaException item)
+    {
+        if (id != item.Id) return BadRequest();
+        _db.Entry(item).State = EntityState.Modified;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("exceptions/{id}")]
+    public async Task<IActionResult> DeleteException(int id)
+    {
+        var item = await _db.AltaExceptions.FindAsync(id);
+        if (item == null) return NotFound();
+        _db.AltaExceptions.Remove(item);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/Logibooks.Core/Controllers/AltaController.cs
+++ b/Logibooks.Core/Controllers/AltaController.cs
@@ -20,8 +20,8 @@ public class AltaController(
     public async Task<ActionResult<int>> Parse([FromBody] List<string> urls)
     {
         var (items, exceptions) = await AltaParser.ParseAsync(urls);
-        if (items.Any()) _db.AltaItems.AddRange(items);
-        if (exceptions.Any()) _db.AltaExceptions.AddRange(exceptions);
+        if (items.Count != 0) _db.AltaItems.AddRange(items);
+        if (exceptions.Count != 0) _db.AltaExceptions.AddRange(exceptions);
         await _db.SaveChangesAsync();
         return items.Count;
     }
@@ -35,7 +35,7 @@ public class AltaController(
     public async Task<ActionResult<AltaItem>> GetItem(int id)
     {
         var item = await _db.AltaItems.FindAsync(id);
-        return item == null ? _404Order(id) : item; // reuse message
+        return item == null ? _404Object(id) : item; 
     }
 
     [HttpPost("items")]
@@ -74,7 +74,7 @@ public class AltaController(
     public async Task<ActionResult<AltaException>> GetException(int id)
     {
         var item = await _db.AltaExceptions.FindAsync(id);
-        return item == null ? _404Order(id) : item; // reuse message
+        return item == null ? _404Object(id) : item;
     }
 
     [HttpPost("exceptions")]

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -74,6 +74,11 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
         return StatusCode(StatusCodes.Status404NotFound,
                           new ErrMessage { Msg = $"Не удалось найти реестр [id={id}]" });
     }
+    protected ObjectResult _404Object(int id)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти j,]trn [id={id}]" });
+    }
     protected ObjectResult _404Order(int id)
     {
         return StatusCode(StatusCodes.Status404NotFound,

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -42,6 +42,8 @@ namespace Logibooks.Core.Data
         public DbSet<Register> Registers => Set<Register>();
         public DbSet<OrderStatus> Statuses => Set<OrderStatus>();
         public DbSet<Order> Orders => Set<Order>();
+        public DbSet<AltaItem> AltaItems => Set<AltaItem>();
+        public DbSet<AltaException> AltaExceptions => Set<AltaException>();
         public async Task<bool> CheckAdmin(int cuid)
         {
             var user = await Users

--- a/Logibooks.Core/Logibooks.Core.csproj
+++ b/Logibooks.Core/Logibooks.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
       <PrivateAssets>all</PrivateAssets>

--- a/Logibooks.Core/Logibooks.Core.csproj
+++ b/Logibooks.Core/Logibooks.Core.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.59" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
       <PrivateAssets>all</PrivateAssets>

--- a/Logibooks.Core/Models/AltaException.cs
+++ b/Logibooks.Core/Models/AltaException.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Logibooks.Core.Models;
+
+[Table("alta_exceptions")]
+public class AltaException
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [Column("number")]
+    public string? Number { get; set; }
+
+    [Column("code")]
+    public string Code { get; set; } = string.Empty;
+
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Column("comment")]
+    public string? Comment { get; set; }
+}

--- a/Logibooks.Core/Models/AltaItem.cs
+++ b/Logibooks.Core/Models/AltaItem.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Logibooks.Core.Models;
+
+[Table("alta_items")]
+public class AltaItem
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [Column("number")]
+    public string? Number { get; set; }
+
+    [Column("code")]
+    public string Code { get; set; } = string.Empty;
+
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Column("comment")]
+    public string? Comment { get; set; }
+}

--- a/Logibooks.Core/Services/AltaParser.cs
+++ b/Logibooks.Core/Services/AltaParser.cs
@@ -1,0 +1,84 @@
+using System.Text.RegularExpressions;
+using HtmlAgilityPack;
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.Services;
+
+public static class AltaParser
+{
+    private static readonly Regex CodePattern = new Regex(@"(\d{4}\s\d{2}\s\d{3}\s\d)", RegexOptions.Compiled);
+
+public static async Task<(List<AltaItem> Items, List<AltaException> Exceptions)> ParseAsync(IEnumerable<string> urls, HttpClient? client = null)
+    {
+        var http = client ?? new HttpClient();
+        var items = new List<AltaItem>();
+        var exceptions = new List<AltaException>();
+
+        foreach (var url in urls)
+        {
+            var html = await http.GetStringAsync(url);
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            var tables = doc.DocumentNode.SelectNodes("//table");
+            if (tables == null) continue;
+
+            foreach (var table in tables)
+            {
+                var rows = table.SelectNodes(".//tr");
+                if (rows == null) continue;
+                foreach (var row in rows)
+                {
+                    var cells = row.SelectNodes("th|td");
+                    if (cells == null) continue;
+                    var vals = cells.Select(c => HtmlEntity.DeEntitize(c.InnerText).Trim()).ToList();
+                    if (vals.Count < 2 || vals.Count > 3) continue;
+
+                    var low = string.Join(" ", vals).ToLower();
+                    if (low.StartsWith("позиция исключена") ||
+                        low.StartsWith("(позиция введена") ||
+                        low.StartsWith("(введено постановлением правительства") ||
+                        low.StartsWith("наименование товара"))
+                        continue;
+
+                    string code = vals.Count == 2 ? vals[1] : vals[1];
+                    string name = vals[0];
+                    string comment = vals.Count == 3 ? vals[2] : string.Empty;
+
+                    var parts = CodePattern.Matches(code);
+                    var codes = parts.Count > 1 ? string.Join(", ", parts.Select(m => m.Value)) : code;
+
+                    foreach (var part in codes.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        var codeClean = part.Trim();
+                        string number = Regex.Match(url, @"(\d{3})/?$").Value;
+                        var item = new AltaItem
+                        {
+                            Url = url,
+                            Number = number,
+                            Code = codeClean.Split('(')[0].Trim().Replace(")", "").Replace(" ", ""),
+                            Name = name,
+                            Comment = comment
+                        };
+                        items.Add(item);
+
+                        if (low.Contains("за исключением"))
+                        {
+                            var excCode = Regex.Replace(code, @".*?\(", "").Trim();
+                            excCode = Regex.Replace(excCode, @"[^\d,]+", "");
+                            exceptions.Add(new AltaException
+                            {
+                                Url = url,
+                                Number = number,
+                                Code = excCode.Replace(" ", ""),
+                                Name = name,
+                                Comment = comment
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        return (items, exceptions);
+    }
+}


### PR DESCRIPTION
## Summary
- add AltaItem and AltaException models and database context fields
- add AltaParser service using HtmlAgilityPack
- provide AltaController with CRUD and parse endpoint
- include HTML parsing unit test
- add HtmlAgilityPack package

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_686a34b207e483219b730607ed6e0fd3