### PR TITLE
Move excel processing to service

### DIFF
--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -56,8 +56,6 @@ public class RegistersControllerTests
     private Role _adminRole;
     private User _logistUser;
     private User _adminUser;
-    private Type _controllerType;
-    private MethodInfo _processExcelMethod;
 #pragma warning restore CS8618
 
     private readonly string testDataDir = Path.Combine(AppContext.BaseDirectory, "test.data");
@@ -100,10 +98,6 @@ public class RegistersControllerTests
         _logger = new LoggerFactory().CreateLogger<RegistersController>();
         _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _logger);
 
-        _controllerType = typeof(RegistersController);
-        _processExcelMethod = _controllerType.GetMethod("ProcessExcel",
-            BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("ProcessExcel method not found");
 
     }
 
@@ -758,40 +752,6 @@ public class RegistersControllerTests
     }
 
     [Test]
-    public async Task ProcessExcel_ReturnsBadRequest_WhenExcelFileIsEmpty()
-    {
-        SetCurrentUserId(1); // Logist user  
-
-        string testFilePath = Path.Combine(testDataDir, "Register_Empty.xlsx");
-        byte[] excelContent;
-
-        try
-        {
-            excelContent = File.ReadAllBytes(testFilePath);
-        }
-        catch (Exception ex)
-        {
-            Assert.Fail($"Test file not found at {testFilePath}: {ex.Message}");
-            return;
-        }
-
-        var mockFile = CreateMockFile("Register_Empty.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", excelContent);
-        var result = await _controller.UploadRegister(mockFile.Object);
-
-        Assert.That(result, Is.TypeOf<ObjectResult>());
-        var objResult = result as ObjectResult;
-        Assert.That(objResult!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
-
-        var errorMessage = objResult.Value as ErrMessage;
-        Assert.That(errorMessage, Is.Not.Null);
-        Assert.That(errorMessage!.Msg, Does.Contain("Пустой файл реестра"));
-
-        // Verify no register was created in the database
-        var registersCount = await _dbContext.Registers.CountAsync();
-        Assert.That(registersCount, Is.EqualTo(0), "No register should be created for an empty Excel file");
-    }
-
-    [Test]
     public async Task UploadRegister_ReturnsBadRequest_WhenZipFileWithoutExcel()
     {
         // Arrange
@@ -873,45 +833,6 @@ public class RegistersControllerTests
         Assert.That(registersCount, Is.EqualTo(0), "No register should be created for unsupported file types");
     }
 
-    private async Task<IActionResult> InvokeProcessExcel(byte[] content, string fileName, string mappingFile = "register_mapping.yaml")
-    {
-        return await (Task<IActionResult>)_processExcelMethod.Invoke(
-            _controller,
-            [content, fileName, mappingFile])!;
-    }
-
-    [Test]
-    public async Task ProcessExcel_Returns500Error_WhenMappingFileNotFound()
-    {
-        // Arrange
-        // Create a sample Excel file content
-        byte[] excelContent = [0x50, 0x4B, 0x03, 0x04]; // Just some dummy content
-
-        // Make sure mapping directory exists but use a non-existent mapping file name
-        string mappingDir = Path.Combine(AppContext.BaseDirectory, "mapping");
-        Directory.CreateDirectory(mappingDir);
-        string nonExistentMappingFile = "non_existent_mapping.yaml";
-        string mappingPath = Path.Combine(mappingDir, nonExistentMappingFile);
-
-        // Delete the mapping file if it somehow exists
-        if (File.Exists(mappingPath))
-        {
-            File.Delete(mappingPath);
-        }
-
-        // Act
-        var result = await InvokeProcessExcel(excelContent, "test.xlsx", nonExistentMappingFile);
-
-        // Assert
-        Assert.That(result, Is.TypeOf<ObjectResult>());
-        var objResult = result as ObjectResult;
-        Assert.That(objResult!.StatusCode, Is.EqualTo(StatusCodes.Status500InternalServerError));
-
-        var errMessage = objResult.Value as ErrMessage;
-        Assert.That(errMessage, Is.Not.Null);
-        Assert.That(errMessage!.Msg, Does.Contain("Не найдена спецификация файла реестра"));
-        Assert.That(errMessage.Msg, Does.Contain(mappingPath));
-    }
 
     [Test]
     public async Task DeleteRegister_DeletesRegisterAndOrders_WhenUserIsLogist()
@@ -974,120 +895,5 @@ public class RegistersControllerTests
             .Returns(Task.CompletedTask);
 
         return mockFile;
-    }
-}
-
-[TestFixture]
-public class ConvertValueToPropertyTypeTests
-{
-#pragma warning disable CS8618
-    private RegistersController _controller;
-#pragma warning restore CS8618
-
-    [SetUp]
-    public void Setup()
-    {
-        // Create a minimal DbContextOptions for AppDbContext
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase($"test_db_{Guid.NewGuid()}")
-            .Options;
-
-        // Pass the valid options to the AppDbContext constructor
-        var dbContext = new AppDbContext(options);
-
-        // Create the controller instance with the valid AppDbContext
-        _controller = (RegistersController)Activator.CreateInstance(
-            typeof(RegistersController),
-            [new Mock<IHttpContextAccessor>().Object, dbContext, new Mock<ILogger<RegistersController>>().Object]
-        )!;
-    }
-
-    [TestCase("42", typeof(int), 42)]
-    [TestCase("notanint", typeof(int), 0)]
-    [TestCase("3.14", typeof(double), 3.14)]
-    [TestCase("2,71", typeof(double), 2.71)] // comma as decimal separator
-    [TestCase("notadouble", typeof(double), 0.0)]
-    [TestCase("123.45", typeof(decimal), 123.45)]
-    [TestCase("67,89", typeof(decimal), 67.89)]
-    [TestCase("notadecimal", typeof(decimal), 0.0)]
-    [TestCase("true", typeof(bool), true)]
-    [TestCase("false", typeof(bool), false)]
-    [TestCase("1", typeof(bool), true)]
-    [TestCase("0", typeof(bool), false)]
-    [TestCase("yeS", typeof(bool), true)]
-    [TestCase("no", typeof(bool), false)]
-    [TestCase("Да", typeof(bool), true)]
-    [TestCase("нет", typeof(bool), false)]
-    [TestCase("", typeof(bool), false)]
-    [TestCase("notabool", typeof(bool), false)]
-    [TestCase("2024-06-28", typeof(DateTime), "2024-06-28")]
-    [TestCase("notadate", typeof(DateTime), "0001-01-01")]
-    [TestCase("2024-06-28", typeof(DateOnly), "2024-06-28")]
-    [TestCase("2024-06-28T13:00:12", typeof(DateOnly), "2024-06-28")]
-    [TestCase("notadate", typeof(DateOnly), "0001-01-01")]
-    [TestCase("hello", typeof(string), "hello")]
-    [TestCase("", typeof(string), "")]
-    [TestCase(null, typeof(string), "")]
-
-    public void ConvertValueToPropertyType_PrimitiveTypes_Works(string? input, Type type, object expected)
-    {
-        var result = _controller.GetType()
-            .GetMethod("ConvertValueToPropertyType", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(_controller, new object?[] { input, type, "TestProp" });
-
-        if (type == typeof(DateTime))
-        {
-            var expectedDate = DateTime.TryParse(expected.ToString(), out var dt) ? dt : default;
-            Assert.That(result, Is.EqualTo(expectedDate));
-        }
-        else if (type == typeof(DateOnly))
-        {
-            var expectedDate = DateOnly.TryParse(expected.ToString(), out var d) ? d : default;
-            Assert.That(result, Is.EqualTo(expectedDate));
-        }
-        else
-        {
-            Assert.That(result, Is.EqualTo(expected));
-        }
-    }
-
-    [Test]
-    public void ConvertValueToPropertyType_NullableInt_ReturnsNullOnNull()
-    {
-        var type = typeof(int?);
-        var result = _controller.GetType()
-            .GetMethod("ConvertValueToPropertyType", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(_controller, new object?[] { null, type, "TestProp" });
-        Assert.That(result, Is.Null);
-    }
-
-    [Test]
-    public void ConvertValueToPropertyType_NullableDouble_ReturnsNullOnEmpty()
-    {
-        var type = typeof(double?);
-        var result = _controller.GetType()
-            .GetMethod("ConvertValueToPropertyType", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(_controller, new object?[] { "", type, "TestProp" });
-        Assert.That(result, Is.Null);
-    }
-
-    [Test]
-    public void ConvertValueToPropertyType_UnknownType_UsesChangeType()
-    {
-        var type = typeof(long);
-        var result = _controller.GetType()
-            .GetMethod("ConvertValueToPropertyType", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(_controller, new object?[] { "123456789", type, "TestProp" });
-        Assert.That(result, Is.EqualTo(123456789L));
-    }
-
-    [Test]
-    public void ConvertValueToPropertyType_UnknownType_ReturnsDefaultOnError()
-    {
-        var type = typeof(Guid);
-        var result = _controller.GetType()
-            .GetMethod("ConvertValueToPropertyType", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(_controller, new object?[] { "notaguid", type, "TestProp" });
-        Assert.That(result, Is.EqualTo(Guid.Empty));
     }
 }

--- a/Logibooks.Core.Tests/Services/RegisterProcessingServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/RegisterProcessingServiceTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Logibooks.Core.Data;
+using Logibooks.Core.Services;
+using Logibooks.Core.Models;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Logibooks.Core.Tests.Services;
+
+[TestFixture]
+public class RegisterProcessingServiceTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private RegisterProcessingService _service;
+#pragma warning restore CS8618
+    private readonly string testDataDir = Path.Combine(AppContext.BaseDirectory, "test.data");
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"service_db_{Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+        var logger = new LoggerFactory().CreateLogger<RegisterProcessingService>();
+        _service = new RegisterProcessingService(_dbContext, logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    [Test]
+    public async Task ProcessExcel_ReturnsEmptyError_WhenExcelFileIsEmpty()
+    {
+        string testFilePath = Path.Combine(testDataDir, "Register_Empty.xlsx");
+        byte[] excelContent = File.ReadAllBytes(testFilePath);
+        var result = await _service.ProcessExcelAsync(excelContent, "Register_Empty.xlsx");
+        Assert.That(result.Error, Is.EqualTo(ProcessExcelError.EmptyExcel));
+    }
+
+    [Test]
+    public async Task ProcessExcel_ReturnsMappingNotFound_WhenMappingFileMissing()
+    {
+        byte[] excelContent = [0x50, 0x4B, 0x03, 0x04];
+        var result = await _service.ProcessExcelAsync(excelContent, "test.xlsx", "non_existent_mapping.yaml");
+        Assert.That(result.Error, Is.EqualTo(ProcessExcelError.MappingNotFound));
+        Assert.That(result.MappingPath, Does.Contain("non_existent_mapping.yaml"));
+    }
+
+    [TestCase("42", typeof(int), 42)]
+    [TestCase("notanint", typeof(int), 0)]
+    [TestCase("3.14", typeof(double), 3.14)]
+    [TestCase("2,71", typeof(double), 2.71)]
+    [TestCase("notadouble", typeof(double), 0.0)]
+    [TestCase("123.45", typeof(decimal), 123.45)]
+    [TestCase("67,89", typeof(decimal), 67.89)]
+    [TestCase("notadecimal", typeof(decimal), 0.0)]
+    [TestCase("true", typeof(bool), true)]
+    [TestCase("false", typeof(bool), false)]
+    [TestCase("1", typeof(bool), true)]
+    [TestCase("0", typeof(bool), false)]
+    [TestCase("yeS", typeof(bool), true)]
+    [TestCase("no", typeof(bool), false)]
+    [TestCase("Да", typeof(bool), true)]
+    [TestCase("нет", typeof(bool), false)]
+    [TestCase("", typeof(bool), false)]
+    [TestCase("notabool", typeof(bool), false)]
+    [TestCase("2024-06-28", typeof(DateTime), "2024-06-28")]
+    [TestCase("notadate", typeof(DateTime), "0001-01-01")]
+    [TestCase("2024-06-28", typeof(DateOnly), "2024-06-28")]
+    [TestCase("2024-06-28T13:00:12", typeof(DateOnly), "2024-06-28")]
+    [TestCase("notadate", typeof(DateOnly), "0001-01-01")]
+    [TestCase("hello", typeof(string), "hello")]
+    [TestCase("", typeof(string), "")]
+    [TestCase(null, typeof(string), "")]
+    public void ConvertValueToPropertyType_PrimitiveTypes_Works(string? input, Type type, object expected)
+    {
+        var result = _service.ConvertValueToPropertyType(input, type, "TestProp");
+        if (type == typeof(DateTime))
+        {
+            var expectedDate = DateTime.TryParse(expected.ToString(), out var dt) ? dt : default;
+            Assert.That(result, Is.EqualTo(expectedDate));
+        }
+        else if (type == typeof(DateOnly))
+        {
+            var expectedDate = DateOnly.TryParse(expected.ToString(), out var d) ? d : default;
+            Assert.That(result, Is.EqualTo(expectedDate));
+        }
+        else
+        {
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+
+    [Test]
+    public void ConvertValueToPropertyType_NullableInt_ReturnsNullOnNull()
+    {
+        var type = typeof(int?);
+        var result = _service.ConvertValueToPropertyType(null, type, "TestProp");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ConvertValueToPropertyType_NullableDouble_ReturnsNullOnEmpty()
+    {
+        var type = typeof(double?);
+        var result = _service.ConvertValueToPropertyType("", type, "TestProp");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ConvertValueToPropertyType_UnknownType_UsesChangeType()
+    {
+        var type = typeof(long);
+        var result = _service.ConvertValueToPropertyType("123456789", type, "TestProp");
+        Assert.That(result, Is.EqualTo(123456789L));
+    }
+
+    [Test]
+    public void ConvertValueToPropertyType_UnknownType_ReturnsDefaultOnError()
+    {
+        var type = typeof(Guid);
+        var result = _service.ConvertValueToPropertyType("notaguid", type, "TestProp");
+        Assert.That(result, Is.EqualTo(Guid.Empty));
+    }
+}

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -35,6 +35,7 @@ using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
 using Logibooks.Core.Settings;
+using Logibooks.Core.Services;
 
 namespace Logibooks.Core.Controllers;
 
@@ -44,8 +45,11 @@ namespace Logibooks.Core.Controllers;
 public class RegistersController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
-    ILogger<RegistersController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
+    ILogger<RegistersController> logger,
+    RegisterProcessingService registerService) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+
+    private readonly RegisterProcessingService _registerService = registerService;
 
     private readonly string[] allowedSortBy = ["id", "filename", "date", "orderstotal"];
     private readonly int maxPageSize = 100;
@@ -243,8 +247,12 @@ public class RegistersController(
                 using var ms = new MemoryStream();
                 await file.CopyToAsync(ms);
                 byte[] excelContent = ms.ToArray();
-                var result = await ProcessExcel(excelContent, file.FileName);
-                return result;
+                var result = await _registerService.ProcessExcelAsync(excelContent, file.FileName);
+                if (result.Error == ProcessExcelError.EmptyExcel)
+                    return _400EmptyRegister();
+                if (result.Error == ProcessExcelError.MappingNotFound)
+                    return _500Mapping(result.MappingPath!);
+                return CreatedAtAction(nameof(UploadRegister), new { id = result.Reference!.Id }, result.Reference);
             }
             else if (fileExtension == ".zip" || fileExtension == ".rar")
             {
@@ -278,9 +286,13 @@ public class RegistersController(
                     excelContent = entryStream.ToArray();
                 }
 
-                var result = await ProcessExcel(excelContent, excelFileName);
+                var result = await _registerService.ProcessExcelAsync(excelContent, excelFileName);
                 _logger.LogDebug("UploadRegister processed archive with Excel");
-                return result;
+                if (result.Error == ProcessExcelError.EmptyExcel)
+                    return _400EmptyRegister();
+                if (result.Error == ProcessExcelError.MappingNotFound)
+                    return _500Mapping(result.MappingPath!);
+                return CreatedAtAction(nameof(UploadRegister), new { id = result.Reference!.Id }, result.Reference);
             }
             else
             {
@@ -342,168 +354,4 @@ public class RegistersController(
                 g => g.ToDictionary(x => x.StatusId, x => x.Count));
     }
 
-    private async Task<IActionResult> ProcessExcel(
-        byte[] content,
-        string fileName, 
-        string mappingFile = "register_mapping.yaml")
-    {
-        _logger.LogDebug("ProcessExcel for {file} ({size} bytes)", fileName, content.Length);
-
-        var mappingPath = Path.Combine(AppContext.BaseDirectory, "mapping", mappingFile);
-        if (!System.IO.File.Exists(mappingPath))
-        {
-            _logger.LogError("Mapping file not found at {path}, ProcessExcel returning '500 Internal Server Error'", mappingPath);
-            return _500Mapping(mappingPath);
-        }
-
-        var mapping = RegisterMapping.Load(mappingPath);
-
-        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
-        using var ms = new MemoryStream(content);
-        using var reader = ExcelReaderFactory.CreateReader(ms);
-        var dataSet = reader.AsDataSet();
-        if (dataSet.Tables.Count == 0 || dataSet.Tables[0].Rows.Count <= 1)
-        {
-            _logger.LogDebug("ProcessExcel returning '400 Bad Request' - Excel file is empty");
-            return _400EmptyRegister();
-        }
-
-        var table = dataSet.Tables[0];
-        var headerRow = table.Rows[0];
-        var columnMap = new Dictionary<int, string>();
-        for (int c = 0; c < table.Columns.Count; c++)
-        {
-            var header = headerRow[c]?.ToString() ?? string.Empty;
-            if (mapping.HeaderMappings.TryGetValue(header, out var prop))
-            {
-                columnMap[c] = prop;
-            }
-        }
-
-        var register = new Register { FileName = fileName };
-        _db.Registers.Add(register);
-        await _db.SaveChangesAsync();
-
-        Reference reference = new() { Id = register.Id };
-
-
-        var orders = new List<Order>();
-        for (int r = 1; r < table.Rows.Count; r++)
-        {
-            var row = table.Rows[r];
-            var order = new Order { RegisterId = register.Id, StatusId = 1 };
-            foreach (var kv in columnMap)
-            {
-                var val = row[kv.Key]?.ToString();
-                var propInfo = typeof(Order).GetProperty(kv.Value);
-                if (propInfo != null)
-                {
-                    if (propInfo != null && val != null)
-                    {
-                        try
-                        {
-                            // Convert string value to appropriate property type
-                            object? convertedValue = ConvertValueToPropertyType(val, propInfo.PropertyType, propInfo.Name);
-                            propInfo.SetValue(order, convertedValue);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Failed to set value '{Value}' for property {Property}",
-                                val, propInfo.Name);
-                            // Continue with next property rather than failing the whole import
-                        }
-                    }
-                }
-            }
-            orders.Add(order);
-        }
-
-        _db.Orders.AddRange(orders);
-        await _db.SaveChangesAsync();
-
-        _logger.LogDebug("ProcessExcel imported {count} orders and is returning Reference with ID: {id}", orders.Count, reference.Id);
-        return CreatedAtAction(nameof(UploadRegister), new { id = reference.Id }, reference);
-        
-    }
-
-    private static readonly CultureInfo RussianCulture = new("ru-RU");
-
-    private object? ConvertValueToPropertyType(string? value, Type propertyType, string propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            // For nullable types or reference types, return null
-            if (propertyType.IsClass || Nullable.GetUnderlyingType(propertyType) != null)
-                return propertyType == typeof(string) ? string.Empty : null;
-
-            // For value types, this will throw an exception if we don't handle specific cases below
-        }
-
-        // Get the underlying type if it's nullable
-        Type targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
-
-        // Handle common types with specific conversion logic
-        if (targetType == typeof(int) || targetType == typeof(Int32))
-        {
-            return int.TryParse(value, NumberStyles.Integer, RussianCulture, out int result) ? result : default;
-        }
-        else if (targetType == typeof(decimal))
-        {
-            // Handle both comma and dot as decimal separators
-            string normalizedVal = value?.Replace('.', ',') ?? "0";
-            return decimal.TryParse(normalizedVal, NumberStyles.AllowDecimalPoint, RussianCulture, out decimal result) ? result : default;
-        }
-        else if (targetType == typeof(double))
-        {
-            string normalizedVal = value?.Replace('.', ',') ?? "0";
-            return double.TryParse(normalizedVal, NumberStyles.AllowDecimalPoint, RussianCulture, out double result) ? result : default;
-        }
-        else if (targetType == typeof(bool))
-        {
-            // Handle various representations of boolean values
-            if (string.IsNullOrWhiteSpace(value))
-                return default(bool);
-
-            string normalizedVal = value.ToLower(RussianCulture).Trim();
-            string[] trueValues = ["1", "yes", "true", "да"];
-
-            if (trueValues.Contains(normalizedVal, StringComparer.InvariantCultureIgnoreCase))
-                return true;
-            else 
-                return false;
-        }
-        else if (targetType == typeof(DateTime))
-        {
-            return DateTime.TryParse(value, RussianCulture, DateTimeStyles.None, out DateTime result) ? result : default;
-        }
-        else if (targetType == typeof(DateOnly))
-        {
-            // Handle DateOnly type - try parsing date portion only
-            if (DateOnly.TryParse(value, RussianCulture, DateTimeStyles.None, out DateOnly result))
-                return result;
-
-            // If direct parsing fails, try parsing as DateTime first and then convert to DateOnly
-            if (DateTime.TryParse(value, RussianCulture, DateTimeStyles.None, out DateTime dateTimeResult))
-                return DateOnly.FromDateTime(dateTimeResult);
-
-            return default(DateOnly);
-        }
-        else if (targetType == typeof(string))
-        {
-            // For string properties, return the value directly or an empty string for null/empty input
-            return value ?? string.Empty;
-        }
-
-        // For other types, try using the default conversion
-        try
-        {
-            return Convert.ChangeType(value, targetType, RussianCulture);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Could not convert '{Value}' to type {Type} for property {Property}",
-                value, targetType.Name, propertyName);
-            return targetType.IsValueType ? Activator.CreateInstance(targetType) : null;
-        }
-    }
 }

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -50,6 +50,7 @@ builder.Services.AddAutoMapper(cfg => cfg.AddProfile<OrderMappingProfile>());
 builder.Services
     .Configure<AppSettings>(builder.Configuration.GetSection("AppSettings"))
     .AddScoped<IJwtUtils, JwtUtils>()
+    .AddScoped<RegisterProcessingService>()
     .AddHttpContextAccessor()
     .AddControllers();
 

--- a/Logibooks.Core/Services/RegisterProcessingService.cs
+++ b/Logibooks.Core/Services/RegisterProcessingService.cs
@@ -1,0 +1,170 @@
+using System.Globalization;
+using ExcelDataReader;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.Settings;
+
+namespace Logibooks.Core.Services;
+
+public enum ProcessExcelError
+{
+    None,
+    MappingNotFound,
+    EmptyExcel
+}
+
+public class ProcessExcelResult
+{
+    public ProcessExcelError Error { get; init; }
+    public string? MappingPath { get; init; }
+    public Reference? Reference { get; init; }
+}
+
+public class RegisterProcessingService
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<RegisterProcessingService> _logger;
+    private static readonly CultureInfo RussianCulture = new("ru-RU");
+
+    public RegisterProcessingService(AppDbContext db, ILogger<RegisterProcessingService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<ProcessExcelResult> ProcessExcelAsync(byte[] content, string fileName, string mappingFile = "register_mapping.yaml")
+    {
+        _logger.LogDebug("ProcessExcel for {file} ({size} bytes)", fileName, content.Length);
+
+        var mappingPath = Path.Combine(AppContext.BaseDirectory, "mapping", mappingFile);
+        if (!System.IO.File.Exists(mappingPath))
+        {
+            _logger.LogError("Mapping file not found at {path}", mappingPath);
+            return new ProcessExcelResult { Error = ProcessExcelError.MappingNotFound, MappingPath = mappingPath };
+        }
+
+        var mapping = RegisterMapping.Load(mappingPath);
+
+        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+        using var ms = new MemoryStream(content);
+        using var reader = ExcelReaderFactory.CreateReader(ms);
+        var dataSet = reader.AsDataSet();
+        if (dataSet.Tables.Count == 0 || dataSet.Tables[0].Rows.Count <= 1)
+        {
+            _logger.LogDebug("ProcessExcel found empty Excel file");
+            return new ProcessExcelResult { Error = ProcessExcelError.EmptyExcel };
+        }
+
+        var table = dataSet.Tables[0];
+        var headerRow = table.Rows[0];
+        var columnMap = new Dictionary<int, string>();
+        for (int c = 0; c < table.Columns.Count; c++)
+        {
+            var header = headerRow[c]?.ToString() ?? string.Empty;
+            if (mapping.HeaderMappings.TryGetValue(header, out var prop))
+            {
+                columnMap[c] = prop;
+            }
+        }
+
+        var register = new Register { FileName = fileName };
+        _db.Registers.Add(register);
+        await _db.SaveChangesAsync();
+
+        var orders = new List<Order>();
+        for (int r = 1; r < table.Rows.Count; r++)
+        {
+            var row = table.Rows[r];
+            var order = new Order { RegisterId = register.Id, StatusId = 1 };
+            foreach (var kv in columnMap)
+            {
+                var val = row[kv.Key]?.ToString();
+                var propInfo = typeof(Order).GetProperty(kv.Value);
+                if (propInfo != null && val != null)
+                {
+                    try
+                    {
+                        object? convertedValue = ConvertValueToPropertyType(val, propInfo.PropertyType, propInfo.Name);
+                        propInfo.SetValue(order, convertedValue);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to set value '{Value}' for property {Property}", val, propInfo.Name);
+                    }
+                }
+            }
+            orders.Add(order);
+        }
+
+        _db.Orders.AddRange(orders);
+        await _db.SaveChangesAsync();
+
+        _logger.LogDebug("ProcessExcel imported {count} orders", orders.Count);
+        return new ProcessExcelResult { Error = ProcessExcelError.None, Reference = new Reference { Id = register.Id } };
+    }
+
+    public object? ConvertValueToPropertyType(string? value, Type propertyType, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            if (propertyType.IsClass || Nullable.GetUnderlyingType(propertyType) != null)
+                return propertyType == typeof(string) ? string.Empty : null;
+        }
+
+        Type targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+        if (targetType == typeof(int) || targetType == typeof(Int32))
+        {
+            return int.TryParse(value, NumberStyles.Integer, RussianCulture, out int result) ? result : default;
+        }
+        else if (targetType == typeof(decimal))
+        {
+            string normalizedVal = value?.Replace('.', ',') ?? "0";
+            return decimal.TryParse(normalizedVal, NumberStyles.AllowDecimalPoint, RussianCulture, out decimal result) ? result : default;
+        }
+        else if (targetType == typeof(double))
+        {
+            string normalizedVal = value?.Replace('.', ',') ?? "0";
+            return double.TryParse(normalizedVal, NumberStyles.AllowDecimalPoint, RussianCulture, out double result) ? result : default;
+        }
+        else if (targetType == typeof(bool))
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return default(bool);
+            string normalizedVal = value.ToLower(RussianCulture).Trim();
+            string[] trueValues = ["1", "yes", "true", "да"];
+            if (trueValues.Contains(normalizedVal, StringComparer.InvariantCultureIgnoreCase))
+                return true;
+            else
+                return false;
+        }
+        else if (targetType == typeof(DateTime))
+        {
+            return DateTime.TryParse(value, RussianCulture, DateTimeStyles.None, out DateTime result) ? result : default;
+        }
+        else if (targetType == typeof(DateOnly))
+        {
+            if (DateOnly.TryParse(value, RussianCulture, DateTimeStyles.None, out DateOnly result))
+                return result;
+            if (DateTime.TryParse(value, RussianCulture, DateTimeStyles.None, out DateTime dateTimeResult))
+                return DateOnly.FromDateTime(dateTimeResult);
+            return default(DateOnly);
+        }
+        else if (targetType == typeof(string))
+        {
+            return value ?? string.Empty;
+        }
+
+        try
+        {
+            return Convert.ChangeType(value, targetType, RussianCulture);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not convert '{Value}' to type {Type} for property {Property}", value, targetType.Name, propertyName);
+            return targetType.IsValueType ? Activator.CreateInstance(targetType) : null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RegisterProcessingService` to handle Excel import logic
- inject `RegisterProcessingService` into `RegistersController`
- provide unit tests for `RegisterProcessingService`
- remove private helpers from controller tests and update Program services

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a8ee1821883218e7c6690664ce1de