### PR TITLE
Implement TnVedCheckService

### DIFF
--- a/Logibooks.Core.Tests/Services/TnVedCheckServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/TnVedCheckServiceTests.cs
@@ -1,0 +1,67 @@
+using System.Threading.Tasks;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.Services;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace Logibooks.Core.Tests.Services;
+
+[TestFixture]
+public class TnVedCheckServiceTests
+{
+    private AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"tnved_service_db_{System.Guid.NewGuid()}")
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Test]
+    public async Task CheckOrder_SetsStatus101_WhenNoException()
+    {
+        using var ctx = CreateContext();
+        ctx.AltaItems.Add(new AltaItem { Code = "123" });
+        ctx.AltaExceptions.Add(new AltaException { Code = "12345" });
+        ctx.Orders.Add(new Order { Id = 1, RegisterId = 1, StatusId = 1, TnVed = "1236" });
+        await ctx.SaveChangesAsync();
+
+        var svc = new TnVedCheckService(ctx);
+        await svc.CheckOrder(1);
+
+        var order = await ctx.Orders.FindAsync(1);
+        Assert.That(order!.StatusId, Is.EqualTo(101));
+    }
+
+    [Test]
+    public async Task CheckOrder_SetsStatus201_WhenExceptionMatches()
+    {
+        using var ctx = CreateContext();
+        ctx.AltaItems.Add(new AltaItem { Code = "123" });
+        ctx.AltaExceptions.Add(new AltaException { Code = "1234" });
+        ctx.Orders.Add(new Order { Id = 1, RegisterId = 1, StatusId = 1, TnVed = "123456" });
+        await ctx.SaveChangesAsync();
+
+        var svc = new TnVedCheckService(ctx);
+        await svc.CheckOrder(1);
+
+        var order = await ctx.Orders.FindAsync(1);
+        Assert.That(order!.StatusId, Is.EqualTo(201));
+    }
+
+    [Test]
+    public async Task CheckOrder_SetsStatus201_WhenNoItemMatch()
+    {
+        using var ctx = CreateContext();
+        ctx.AltaItems.Add(new AltaItem { Code = "999" });
+        ctx.Orders.Add(new Order { Id = 1, RegisterId = 1, StatusId = 1, TnVed = "123456" });
+        await ctx.SaveChangesAsync();
+
+        var svc = new TnVedCheckService(ctx);
+        await svc.CheckOrder(1);
+
+        var order = await ctx.Orders.FindAsync(1);
+        Assert.That(order!.StatusId, Is.EqualTo(201));
+    }
+}

--- a/Logibooks.Core/Services/TnVedCheckService.cs
+++ b/Logibooks.Core/Services/TnVedCheckService.cs
@@ -1,0 +1,45 @@
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Logibooks.Core.Services;
+
+public class TnVedCheckService
+{
+    private readonly AppDbContext _db;
+    private readonly Dictionary<string, HashSet<string>> _map = new();
+
+    public TnVedCheckService(AppDbContext db)
+    {
+        _db = db;
+        var items = _db.AltaItems.AsNoTracking().Select(i => i.Code).ToList();
+        var exceptions = _db.AltaExceptions.AsNoTracking().Select(e => e.Code).ToList();
+        foreach (var item in items)
+        {
+            var exSet = exceptions.Where(e => e.StartsWith(item)).ToHashSet();
+            _map[item] = exSet;
+        }
+    }
+
+    public async Task CheckOrder(int orderId)
+    {
+        var order = await _db.Orders.FirstOrDefaultAsync(o => o.Id == orderId);
+        if (order == null) return;
+        string? tn = order.TnVed;
+        int status = 201;
+        if (!string.IsNullOrEmpty(tn))
+        {
+            foreach (var kv in _map)
+            {
+                if (tn.StartsWith(kv.Key))
+                {
+                    bool except = kv.Value.Any(ex => tn.StartsWith(ex));
+                    status = except ? 201 : 101;
+                    break;
+                }
+            }
+        }
+        order.StatusId = status;
+        await _db.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add TnVedCheckService for validating orders against Alta lists
- unit tests verifying status update logic

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae73232188321aa6fea08aaf8f23f