### PR TITLE
Add CountryCode model

### DIFF
--- a/Logibooks.Core.Tests/Models/CountryCodeTests.cs
+++ b/Logibooks.Core.Tests/Models/CountryCodeTests.cs
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using NUnit.Framework;
+using Logibooks.Core.Models;
+using System;
+
+namespace Logibooks.Core.Tests.Models;
+
+public class CountryCodeTests
+{
+    [Test]
+    public void LoadedAt_DefaultsToUtcNow()
+    {
+        var before = DateTime.UtcNow;
+        var cc = new CountryCode { IsoNumeric = 123, IsoAlpha2 = "AA" };
+        var after = DateTime.UtcNow;
+        Assert.That(cc.LoadedAt, Is.GreaterThanOrEqualTo(before).And.LessThanOrEqualTo(after));
+    }
+}

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -44,6 +44,7 @@ namespace Logibooks.Core.Data
         public DbSet<Order> Orders => Set<Order>();
         public DbSet<AltaItem> AltaItems => Set<AltaItem>();
         public DbSet<AltaException> AltaExceptions => Set<AltaException>();
+        public DbSet<CountryCode> CountryCodes => Set<CountryCode>();
         public async Task<bool> CheckAdmin(int cuid)
         {
             var user = await Users
@@ -112,6 +113,9 @@ namespace Logibooks.Core.Data
 
             modelBuilder.Entity<UserRole>()
                 .HasKey(ur => new { ur.UserId, ur.RoleId });
+
+            modelBuilder.Entity<CountryCode>()
+                .HasKey(cc => cc.IsoNumeric);
 
             modelBuilder.Entity<UserRole>()
                 .HasOne(ur => ur.User)

--- a/Logibooks.Core/Migrations/20250709101019_AddCountryCodes.Designer.cs
+++ b/Logibooks.Core/Migrations/20250709101019_AddCountryCodes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Logibooks.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Logibooks.Core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250709101019_AddCountryCodes")]
+    partial class AddCountryCodes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Logibooks.Core/Migrations/20250709101019_AddCountryCodes.cs
+++ b/Logibooks.Core/Migrations/20250709101019_AddCountryCodes.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Logibooks.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCountryCodes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "country_codes",
+                columns: table => new
+                {
+                    iso_numeric = table.Column<short>(type: "smallint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    iso_alpha2 = table.Column<string>(type: "text", nullable: false),
+                    name_en_short = table.Column<string>(type: "text", nullable: true),
+                    name_en_formal = table.Column<string>(type: "text", nullable: true),
+                    name_en_official = table.Column<string>(type: "text", nullable: true),
+                    name_en_cldr = table.Column<string>(type: "text", nullable: true),
+                    name_ru_short = table.Column<string>(type: "text", nullable: true),
+                    name_ru_formal = table.Column<string>(type: "text", nullable: true),
+                    name_ru_official = table.Column<string>(type: "text", nullable: true),
+                    loaded_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_country_codes", x => x.iso_numeric);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "country_codes");
+        }
+    }
+}

--- a/Logibooks.Core/Models/CountryCode.cs
+++ b/Logibooks.Core/Models/CountryCode.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Logibooks.Core.Models;
+
+[Table("country_codes")]
+public class CountryCode
+{
+    [Column("iso_numeric")]
+    public short IsoNumeric { get; set; }
+
+    [Column("iso_alpha2")]
+    public required string IsoAlpha2 { get; set; }
+
+    [Column("name_en_short")]
+    public string? NameEnShort { get; set; }
+
+    [Column("name_en_formal")]
+    public string? NameEnFormal { get; set; }
+
+    [Column("name_en_official")]
+    public string? NameEnOfficial { get; set; }
+
+    [Column("name_en_cldr")]
+    public string? NameEnCldr { get; set; }
+
+    [Column("name_ru_short")]
+    public string? NameRuShort { get; set; }
+
+    [Column("name_ru_formal")]
+    public string? NameRuFormal { get; set; }
+
+    [Column("name_ru_official")]
+    public string? NameRuOfficial { get; set; }
+
+    [Column("loaded_at")]
+    public DateTime LoadedAt { get; set; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary
- add `CountryCode` model representing `country_codes` table
- register `CountryCode` in `AppDbContext`
- add EF Core migration for `country_codes`
- cover default `LoadedAt` value with unit test

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_686e3f1518b48321bdaaf83f1a7b4cb9