### PR TITLE
Add country code management improvements

### DIFF
--- a/Logibooks.Core.Tests/Controllers/CountryCodesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/CountryCodesControllerTests.cs
@@ -1,0 +1,128 @@
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Logibooks.Core.Controllers;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
+
+namespace Logibooks.Core.Tests.Controllers;
+
+[TestFixture]
+public class CountryCodesControllerTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private Mock<ILogger<CountryCodesController>> _mockLogger;
+    private Mock<IUpdateCountryCodesService> _mockService;
+    private CountryCodesController _controller;
+    private Role _adminRole;
+    private Role _userRole;
+    private User _adminUser;
+    private User _regularUser;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"cc_controller_db_{System.Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { Id = 1, Name = "administrator", Title = "Admin" };
+        _userRole = new Role { Id = 2, Name = "user", Title = "User" };
+        _dbContext.Roles.AddRange(_adminRole, _userRole);
+
+        string hpw = BCrypt.Net.BCrypt.HashPassword("pwd");
+        _adminUser = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = hpw,
+            UserRoles = [ new UserRole { UserId = 1, RoleId = 1, Role = _adminRole } ]
+        };
+        _regularUser = new User
+        {
+            Id = 2,
+            Email = "user@example.com",
+            Password = hpw,
+            UserRoles = [ new UserRole { UserId = 2, RoleId = 2, Role = _userRole } ]
+        };
+        _dbContext.Users.AddRange(_adminUser, _regularUser);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _mockLogger = new Mock<ILogger<CountryCodesController>>();
+        _mockService = new Mock<IUpdateCountryCodesService>();
+        _controller = new CountryCodesController(_mockHttpContextAccessor.Object, _dbContext, _mockService.Object, _mockLogger.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    private void SetCurrentUserId(int id)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Items["UserId"] = id;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
+        _controller = new CountryCodesController(_mockHttpContextAccessor.Object, _dbContext, _mockService.Object, _mockLogger.Object);
+    }
+
+    [Test]
+    public async Task Update_ReturnsForbidden_ForNonAdmin()
+    {
+        SetCurrentUserId(2);
+        var result = await _controller.Update();
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Update_RunsService_ForAdmin()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.Update();
+        _mockService.Verify(s => s.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task GetCodes_ReturnsList_ForAnyUser()
+    {
+        SetCurrentUserId(2);
+        _dbContext.CountryCodes.AddRange(new CountryCode { IsoNumeric = 840, IsoAlpha2 = "US" },
+                                         new CountryCode { IsoNumeric = 124, IsoAlpha2 = "CA" });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetCodes();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetCode_ReturnsRecord_ForAnyUser()
+    {
+        SetCurrentUserId(2);
+        _dbContext.CountryCodes.Add(new CountryCode { IsoNumeric = 840, IsoAlpha2 = "US" });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetCode(840);
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.IsoNumeric, Is.EqualTo(840));
+    }
+}

--- a/Logibooks.Core.Tests/Logibooks.Core.Tests.csproj
+++ b/Logibooks.Core.Tests/Logibooks.Core.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/Logibooks.Core.Tests/Services/UpdateCountryCodesJobTests.cs
+++ b/Logibooks.Core.Tests/Services/UpdateCountryCodesJobTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Quartz;
+using Logibooks.Core.Services;
+
+namespace Logibooks.Core.Tests.Services;
+
+public class DummyUpdateService : IUpdateCountryCodesService
+{
+    public List<CancellationToken> Tokens { get; } = new();
+    public TaskCompletionSource Started { get; } = new();
+    public TaskCompletionSource Cancelled { get; } = new();
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        Tokens.Add(cancellationToken);
+        Started.TrySetResult();
+        try
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            Cancelled.TrySetResult();
+            throw;
+        }
+    }
+}
+
+[TestFixture]
+public class UpdateCountryCodesJobTests
+{
+    [Test]
+    public async Task Execute_CancelsPreviousJob()
+    {
+        var service = new DummyUpdateService();
+        var job1 = new UpdateCountryCodesJob(service, NullLogger<UpdateCountryCodesJob>.Instance);
+        var ctx1 = new Mock<IJobExecutionContext>();
+        ctx1.Setup(c => c.CancellationToken).Returns(CancellationToken.None);
+        var task1 = job1.Execute(ctx1.Object);
+        await service.Started.Task; // first started
+
+        var job2 = new UpdateCountryCodesJob(service, NullLogger<UpdateCountryCodesJob>.Instance);
+        var cts2 = new CancellationTokenSource();
+        var ctx2 = new Mock<IJobExecutionContext>();
+        ctx2.Setup(c => c.CancellationToken).Returns(cts2.Token);
+        var task2 = job2.Execute(ctx2.Object);
+        await service.Cancelled.Task; // first cancelled by second start
+        Assert.That(service.Tokens[0].IsCancellationRequested, Is.True);
+        cts2.Cancel();
+        try { await task2; } catch { }
+        try { await task1; } catch { }
+    }
+}

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -52,7 +52,7 @@ builder.Services.AddAutoMapper(cfg => cfg.AddProfile<OrderMappingProfile>());
 builder.Services
     .Configure<AppSettings>(builder.Configuration.GetSection("AppSettings"))
     .AddScoped<IJwtUtils, JwtUtils>()
-    .AddScoped<UpdateCountryCodesService>()
+    .AddScoped<IUpdateCountryCodesService, UpdateCountryCodesService>()
     .AddHttpContextAccessor()
     .AddControllers();
 

--- a/Logibooks.Core/RestModels/CountryCodeDto.cs
+++ b/Logibooks.Core/RestModels/CountryCodeDto.cs
@@ -1,0 +1,32 @@
+namespace Logibooks.Core.RestModels;
+
+using Logibooks.Core.Models;
+
+public class CountryCodeDto
+{
+    public short IsoNumeric { get; set; }
+    public string IsoAlpha2 { get; set; } = string.Empty;
+    public string NameEnShort { get; set; } = string.Empty;
+    public string NameEnFormal { get; set; } = string.Empty;
+    public string NameEnOfficial { get; set; } = string.Empty;
+    public string NameEnCldr { get; set; } = string.Empty;
+    public string NameRuShort { get; set; } = string.Empty;
+    public string NameRuFormal { get; set; } = string.Empty;
+    public string NameRuOfficial { get; set; } = string.Empty;
+    public DateTime LoadedAt { get; set; }
+
+    public CountryCodeDto() {}
+    public CountryCodeDto(CountryCode cc)
+    {
+        IsoNumeric = cc.IsoNumeric;
+        IsoAlpha2 = cc.IsoAlpha2;
+        NameEnShort = cc.NameEnShort;
+        NameEnFormal = cc.NameEnFormal;
+        NameEnOfficial = cc.NameEnOfficial;
+        NameEnCldr = cc.NameEnCldr;
+        NameRuShort = cc.NameRuShort;
+        NameRuFormal = cc.NameRuFormal;
+        NameRuOfficial = cc.NameRuOfficial;
+        LoadedAt = cc.LoadedAt;
+    }
+}

--- a/Logibooks.Core/Services/IUpdateCountryCodesService.cs
+++ b/Logibooks.Core/Services/IUpdateCountryCodesService.cs
@@ -1,0 +1,6 @@
+namespace Logibooks.Core.Services;
+
+public interface IUpdateCountryCodesService
+{
+    Task RunAsync(CancellationToken cancellationToken = default);
+}

--- a/Logibooks.Core/Services/UpdateCountryCodesService.cs
+++ b/Logibooks.Core/Services/UpdateCountryCodesService.cs
@@ -36,6 +36,7 @@ public class UpdateCountryCodesService(
     AppDbContext db,
     ILogger<UpdateCountryCodesService> logger,
     IHttpClientFactory httpClientFactory)
+    : IUpdateCountryCodesService
 {
     private readonly AppDbContext _db = db;
     private readonly ILogger<UpdateCountryCodesService> _logger = logger;


### PR DESCRIPTION
## Summary
- allow manual update of country codes only for admin users
- expose GET endpoints for country code list and details
- cancel previous UpdateCountryCodesJob when starting a new one
- refactor job/service to use IUpdateCountryCodesService interface
- add DTO for country codes
- cover new behaviour with tests

## Testing
- `dotnet build Logibooks.sln`
- `dotnet vstest Logibooks.Core.Tests/bin/Debug/net8.0/Logibooks.Core.Tests.dll --TestAdapterPath:.`

------
https://chatgpt.com/codex/tasks/task_e_686e912f366c8321ab43a2c8f3b74fee