### PR TITLE
Add compact country codes API

### DIFF
--- a/Logibooks.Core.Tests/Controllers/CountryCodesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/CountryCodesControllerTests.cs
@@ -138,4 +138,29 @@ public class CountryCodesControllerTests
         Assert.That(result.Value, Is.Not.Null);
         Assert.That(result.Value!.IsoNumeric, Is.EqualTo(840));
     }
+
+    [Test]
+    public async Task GetCodesCompact_OrdersAndSelectsProperly()
+    {
+        SetCurrentUserId(2);
+        _dbContext.CountryCodes.AddRange(
+            new CountryCode { IsoNumeric = 643, IsoAlpha2 = "RU", NameEnOfficial = "RU", NameRuOfficial = "RU" },
+            new CountryCode { IsoNumeric = 860, IsoAlpha2 = "UZ", NameEnOfficial = "UZ", NameRuOfficial = "UZ" },
+            new CountryCode { IsoNumeric = 268, IsoAlpha2 = "GE", NameEnOfficial = "GE", NameRuOfficial = "GE" },
+            new CountryCode { IsoNumeric = 31,  IsoAlpha2 = "AZ", NameEnOfficial = "AZ", NameRuOfficial = "AZ" },
+            new CountryCode { IsoNumeric = 792, IsoAlpha2 = "TR", NameEnOfficial = "TR", NameRuOfficial = "TR" },
+            new CountryCode { IsoNumeric = 124, IsoAlpha2 = "CA", NameEnOfficial = "CA", NameRuOfficial = "CA" },
+            new CountryCode { IsoNumeric = 398, IsoAlpha2 = "KZ", NameEnOfficial = "KZ", NameRuOfficial = "KZ" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetCodesCompact();
+        var list = result.Value!.ToList();
+
+        string[] expectedFirst = ["RU", "UZ", "GE", "AZ", "TR"];
+        Assert.That(list.Take(5).Select(c => c.IsoAlpha2), Is.EqualTo(expectedFirst));
+        var rest = list.Skip(5).Select(c => c.IsoNumeric).ToList();
+        Assert.That(rest, Is.EqualTo(rest.OrderBy(n => n).ToList()));
+        Assert.That(list.All(c => c.NameEnOfficial != string.Empty && c.NameRuOfficial != string.Empty));
+    }
 }

--- a/Logibooks.Core/Controllers/CountryCodesController.cs
+++ b/Logibooks.Core/Controllers/CountryCodesController.cs
@@ -57,13 +57,17 @@ public class CountryCodesController(
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CountryCodeCompactDto>))]
     public async Task<ActionResult<IEnumerable<CountryCodeCompactDto>>> GetCodesCompact()
     {
+        var priorityMapping = new Dictionary<string, int>
+        {
+            { "RU", 0 },
+            { "UZ", 1 },
+            { "GE", 2 },
+            { "AZ", 3 },
+            { "TR", 4 }
+        };
+
         var codes = await _db.CountryCodes.AsNoTracking()
-            .OrderBy(c => c.IsoAlpha2 == "RU" ? 0
-                         : c.IsoAlpha2 == "UZ" ? 1
-                         : c.IsoAlpha2 == "GE" ? 2
-                         : c.IsoAlpha2 == "AZ" ? 3
-                         : c.IsoAlpha2 == "TR" ? 4
-                         : 5)
+            .OrderBy(c => priorityMapping.GetValueOrDefault(c.IsoAlpha2, int.MaxValue))
             .ThenBy(c => c.IsoNumeric)
             .Select(c => new CountryCodeCompactDto(c))
             .ToListAsync();

--- a/Logibooks.Core/Controllers/CountryCodesController.cs
+++ b/Logibooks.Core/Controllers/CountryCodesController.cs
@@ -53,6 +53,24 @@ public class CountryCodesController(
         return codes.Select(c => new CountryCodeDto(c)).ToList();
     }
 
+    [HttpGet("compact")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CountryCodeCompactDto>))]
+    public async Task<ActionResult<IEnumerable<CountryCodeCompactDto>>> GetCodesCompact()
+    {
+        var codes = await _db.CountryCodes.AsNoTracking()
+            .OrderBy(c => c.IsoAlpha2 == "RU" ? 0
+                         : c.IsoAlpha2 == "UZ" ? 1
+                         : c.IsoAlpha2 == "GE" ? 2
+                         : c.IsoAlpha2 == "AZ" ? 3
+                         : c.IsoAlpha2 == "TR" ? 4
+                         : 5)
+            .ThenBy(c => c.IsoNumeric)
+            .Select(c => new CountryCodeCompactDto(c))
+            .ToListAsync();
+
+        return codes;
+    }
+
     [HttpGet("{id}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CountryCodeDto))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]

--- a/Logibooks.Core/RestModels/CountryCodeCompactDto.cs
+++ b/Logibooks.Core/RestModels/CountryCodeCompactDto.cs
@@ -1,0 +1,20 @@
+namespace Logibooks.Core.RestModels;
+
+using Logibooks.Core.Models;
+
+public class CountryCodeCompactDto
+{
+    public short IsoNumeric { get; set; }
+    public string IsoAlpha2 { get; set; } = string.Empty;
+    public string NameEnOfficial { get; set; } = string.Empty;
+    public string NameRuOfficial { get; set; } = string.Empty;
+
+    public CountryCodeCompactDto() {}
+    public CountryCodeCompactDto(CountryCode cc)
+    {
+        IsoNumeric = cc.IsoNumeric;
+        IsoAlpha2 = cc.IsoAlpha2;
+        NameEnOfficial = cc.NameEnOfficial;
+        NameRuOfficial = cc.NameRuOfficial;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `GetCodesCompact` endpoint in `CountryCodesController`
- add `CountryCodeCompactDto` with minimal fields
- test the compact endpoint ordering and field selection

## Testing
- `dotnet test Logibooks.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ed0de49c483218cfed6c167f8c8d6