### PR TITLE
Add order status endpoints

### DIFF
--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -318,5 +318,33 @@ public class OrdersControllerTests
         Assert.That(pr!.Pagination.CurrentPage, Is.EqualTo(1));
         Assert.That(pr.Items.First().Id, Is.EqualTo(1));
     }
+
+    [Test]
+    public async Task GetOrderStatus_ReturnsTitle_WhenExists()
+    {
+        var status = new OrderStatus { Id = 1, Title = "Loaded" };
+        _dbContext.Statuses.Add(status);
+        var reg = new Register { Id = 1, FileName = "r.xlsx" };
+        var order = new Order { Id = 1, RegisterId = 1, StatusId = 1, OrderNumber = "A1" };
+        _dbContext.Registers.Add(reg);
+        _dbContext.Orders.Add(order);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetOrderStatus("A1");
+
+        Assert.That(result.Result, Is.TypeOf<OkObjectResult>());
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok!.Value, Is.EqualTo("Loaded"));
+    }
+
+    [Test]
+    public async Task GetOrderStatus_ReturnsNotFound_WhenMissing()
+    {
+        var result = await _controller.GetOrderStatus("NO");
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
 }
 

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -1111,4 +1111,64 @@ public class ConvertValueToPropertyTypeTests
             .Invoke(_controller, new object?[] { "notaguid", type, "TestProp" });
         Assert.That(result, Is.EqualTo(Guid.Empty));
     }
+
+    [Test]
+    public async Task SetOrderStatuses_UpdatesOrders()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Statuses.AddRange(
+            new OrderStatus { Id = 1, Title = "Old" },
+            new OrderStatus { Id = 2, Title = "New" });
+        var reg = new Register { Id = 1, FileName = "r.xlsx" };
+        _dbContext.Registers.Add(reg);
+        _dbContext.Orders.AddRange(
+            new Order { Id = 1, RegisterId = 1, StatusId = 1 },
+            new Order { Id = 2, RegisterId = 1, StatusId = 1 });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.SetOrderStatuses(1, 2);
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+        Assert.That(_dbContext.Orders.All(o => o.StatusId == 2));
+    }
+
+    [Test]
+    public async Task SetOrderStatuses_ReturnsNotFound_WhenRegisterMissing()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Statuses.Add(new OrderStatus { Id = 1, Title = "S" });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.SetOrderStatuses(99, 1);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task SetOrderStatuses_ReturnsNotFound_WhenStatusMissing()
+    {
+        SetCurrentUserId(1);
+        var reg = new Register { Id = 1, FileName = "r.xlsx" };
+        _dbContext.Registers.Add(reg);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.SetOrderStatuses(1, 5);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task SetOrderStatuses_ReturnsForbidden_ForNonLogist()
+    {
+        SetCurrentUserId(2); // admin but not logist
+        var result = await _controller.SetOrderStatuses(1, 1);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
 }

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -84,6 +84,11 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
         return StatusCode(StatusCodes.Status404NotFound,
                           new ErrMessage { Msg = $"Не удалось найти заказ [id={id}]" });
     }
+    protected ObjectResult _404OrderNumber(string number)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти заказ [номер={number}]" });
+    }
     protected ObjectResult _409Email(string email)
     {
         return StatusCode(StatusCodes.Status409Conflict,

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -26,7 +26,6 @@
 using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Authorization;
 
 using Logibooks.Core.Authorization;
 using Logibooks.Core.Data;

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -359,7 +359,7 @@ public class RegistersController(
         if (!await _db.Statuses.AnyAsync(s => s.Id == statusId))
         {
             _logger.LogDebug("SetOrderStatuses returning '404 Not Found' - status");
-            return _404Object(statusId);
+            return _404Status(statusId);
         }
 
         await _db.Orders


### PR DESCRIPTION
## Summary
- add `_404OrderNumber` helper for missing orders by number
- bulk update register orders with new `SetOrderStatuses` API
- expose new anonymous `GetOrderStatus` endpoint
- test order status API and register order status updates

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687183614ba08321b6f280f45583a1ed