### PR TITLE
Implement StopWord CRUD

### DIFF
--- a/Logibooks.Core.Tests/Controllers/StopWordsControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StopWordsControllerTests.cs
@@ -1,0 +1,158 @@
+using Logibooks.Core.Controllers;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Logibooks.Core.Tests.Controllers;
+
+[TestFixture]
+public class StopWordsControllerTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private ILogger<StopWordsController> _logger;
+    private StopWordsController _controller;
+    private Role _adminRole;
+    private Role _logistRole;
+    private User _adminUser;
+    private User _logistUser;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"stop_words_controller_db_{System.Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { Id = 1, Name = "administrator", Title = "Администратор" };
+        _logistRole = new Role { Id = 2, Name = "logist", Title = "Логист" };
+        _dbContext.Roles.AddRange(_adminRole, _logistRole);
+
+        string hpw = BCrypt.Net.BCrypt.HashPassword("pwd");
+        _adminUser = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = hpw,
+            UserRoles = [new UserRole { UserId = 1, RoleId = 1, Role = _adminRole }]
+        };
+        _logistUser = new User
+        {
+            Id = 2,
+            Email = "logist@example.com",
+            Password = hpw,
+            UserRoles = [new UserRole { UserId = 2, RoleId = 2, Role = _logistRole }]
+        };
+        _dbContext.Users.AddRange(_adminUser, _logistUser);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _logger = new LoggerFactory().CreateLogger<StopWordsController>();
+        _controller = new StopWordsController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    private void SetCurrentUserId(int id)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Items["UserId"] = id;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
+        _controller = new StopWordsController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+    }
+
+    [Test]
+    public async Task GetStopWords_ReturnsAll_ForLogist()
+    {
+        SetCurrentUserId(2);
+        _dbContext.StopWord.AddRange(new StopWord { Id = 1, Word = "a" }, new StopWord { Id = 2, Word = "b" });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetStopWords();
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task CreateUpdateDelete_Work_ForAdmin()
+    {
+        SetCurrentUserId(1);
+        var dto = new StopWordDto { Word = "test", ExactMatch = false };
+        var created = await _controller.PostStopWord(dto);
+        Assert.That(created.Result, Is.TypeOf<CreatedAtActionResult>());
+        var createdDto = (created.Result as CreatedAtActionResult)!.Value as StopWordDto;
+        Assert.That(createdDto!.Id, Is.GreaterThan(0));
+
+        var id = createdDto.Id;
+        createdDto.Word = "updated";
+        var upd = await _controller.PutStopWord(id, createdDto);
+        Assert.That(upd, Is.TypeOf<NoContentResult>());
+
+        var del = await _controller.DeleteStopWord(id);
+        Assert.That(del, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task Create_ReturnsForbidden_ForNonAdmin()
+    {
+        SetCurrentUserId(2);
+        var dto = new StopWordDto { Word = "w" };
+        var result = await _controller.PostStopWord(dto);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task DeleteStopWord_ReturnsConflict_WhenUsed()
+    {
+        SetCurrentUserId(1);
+        var word = new StopWord { Id = 5, Word = "used" };
+        var reg = new Register { Id = 1, FileName = "r" };
+        var order = new WbrOrder { Id = 1, RegisterId = 1 };
+        var link = new BaseOrderStopWord { BaseOrderId = 1, StopWordId = 5, BaseOrder = order, StopWord = word };
+        _dbContext.StopWord.Add(word);
+        _dbContext.Registers.Add(reg);
+        _dbContext.Orders.Add(order);
+        _dbContext.Add(link);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.DeleteStopWord(5);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+    }
+
+    [Test]
+    public async Task GetStopWord_ReturnsWord_WhenExists()
+    {
+        SetCurrentUserId(2);
+        var word = new StopWord { Id = 6, Word = "find" };
+        _dbContext.StopWord.Add(word);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetStopWord(6);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Word, Is.EqualTo("find"));
+    }
+}

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -119,6 +119,16 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
         return StatusCode(StatusCodes.Status409Conflict,
                           new ErrMessage { Msg = $"Невозможно удалить реестр, на который ссылаются заказы" });
     }
+    protected ObjectResult _409StopWord(string word)
+    {
+        return StatusCode(StatusCodes.Status409Conflict,
+                          new ErrMessage { Msg = $"Стоп-слово уже существует [слово = {word}]" });
+    }
+    protected ObjectResult _409StopWordUsed()
+    {
+        return StatusCode(StatusCodes.Status409Conflict,
+                          new ErrMessage { Msg = $"Невозможно удалить стоп-слово, на которое ссылаются заказы" });
+    }
 
     protected ObjectResult _500Mapping(string fname)
     {

--- a/Logibooks.Core/Controllers/StopWordsController.cs
+++ b/Logibooks.Core/Controllers/StopWordsController.cs
@@ -1,0 +1,121 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using Logibooks.Core.Authorization;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+
+namespace Logibooks.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class StopWordsController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    ILogger<StopWordsController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<StopWordDto>))]
+    public async Task<ActionResult<IEnumerable<StopWordDto>>> GetStopWords()
+    {
+        var words = await _db.StopWord.AsNoTracking().OrderBy(w => w.Id).ToListAsync();
+        return words.Select(w => new StopWordDto(w)).ToList();
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(StopWordDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<StopWordDto>> GetStopWord(int id)
+    {
+        var word = await _db.StopWord.AsNoTracking().FirstOrDefaultAsync(w => w.Id == id);
+        return word == null ? _404Object(id) : new StopWordDto(word);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(StopWordDto))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<StopWordDto>> PostStopWord(StopWordDto dto)
+    {
+        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (await _db.StopWord.AnyAsync(sw => sw.Word.ToLower() == dto.Word.ToLower()))
+        {
+            return _409StopWord(dto.Word);
+        }
+        var sw = dto.ToModel();
+        _db.StopWord.Add(sw);
+        try
+        {
+            await _db.SaveChangesAsync();
+            dto.Id = sw.Id;
+            return CreatedAtAction(nameof(GetStopWord), new { id = sw.Id }, dto);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException?.Message?.Contains("IX_stop_words_word") == true)
+        {
+            _logger.LogDebug("PostStopWord returning '409 Conflict' due to database constraint");
+            return _409StopWord(dto.Word);
+        }
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> PutStopWord(int id, StopWordDto dto)
+    {
+        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (id != dto.Id) return BadRequest();
+        var sw = await _db.StopWord.FindAsync(id);
+        if (sw == null) return _404Object(id);
+        if (!sw.Word.Equals(dto.Word, StringComparison.OrdinalIgnoreCase) &&
+            await _db.StopWord.AnyAsync(w => w.Word.ToLower() == dto.Word.ToLower()))
+        {
+            return _409StopWord(dto.Word);
+        }
+        sw.Word = dto.Word;
+        sw.ExactMatch = dto.ExactMatch;
+        try
+        {
+            _db.Entry(sw).State = EntityState.Modified;
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+        catch (DbUpdateException ex) when (ex.InnerException?.Message?.Contains("IX_stop_words_word") == true)
+        {
+            _logger.LogDebug("PutStopWord returning '409 Conflict' due to database constraint");
+            return _409StopWord(dto.Word);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteStopWord(int id)
+    {
+        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        var sw = await _db.StopWord.FindAsync(id);
+        if (sw == null) return _404Object(id);
+
+        bool hasOrders = await _db.Set<BaseOrderStopWord>().AnyAsync(r => r.StopWordId == id);
+        if (hasOrders)
+        {
+            return _409StopWordUsed();
+        }
+
+        _db.StopWord.Remove(sw);
+        try
+        {
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+        catch (DbUpdateException)
+        {
+            return _409StopWordUsed();
+        }
+    }
+}

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -189,6 +189,10 @@ namespace Logibooks.Core.Data
                 .WithMany(sw => sw.BaseOrderStopWords)
                 .HasForeignKey(bosw => bosw.StopWordId);
 
+            modelBuilder.Entity<StopWord>()
+                .HasIndex(sw => sw.Word)
+                .IsUnique();
+
             modelBuilder.Entity<Role>().HasData(
                 new Role { Id = 1, Name = "logist", Title = "Логист" },
                 new Role { Id = 2, Name = "administrator", Title = "Администратор" }

--- a/Logibooks.Core/RestModels/StopWordDto.cs
+++ b/Logibooks.Core/RestModels/StopWordDto.cs
@@ -1,0 +1,28 @@
+namespace Logibooks.Core.RestModels;
+
+using Logibooks.Core.Models;
+
+public class StopWordDto
+{
+    public int Id { get; set; }
+    public string Word { get; set; } = string.Empty;
+    public bool ExactMatch { get; set; }
+
+    public StopWordDto() {}
+    public StopWordDto(StopWord sw)
+    {
+        Id = sw.Id;
+        Word = sw.Word;
+        ExactMatch = sw.ExactMatch;
+    }
+
+    public StopWord ToModel()
+    {
+        return new StopWord
+        {
+            Id = Id,
+            Word = Word,
+            ExactMatch = ExactMatch
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add StopWordDto
- support StopWord operations through StopWordsController
- add helper methods to base controller for StopWord conflicts
- enforce unique index on StopWord.Word
- cover StopWordsController with unit tests

## Testing
- `dotnet test Logibooks.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68761ef7187c8321b6d0ded4ef11a7d4