### PR TITLE
Rename StopWord DbSet

### DIFF
--- a/Logibooks.Core.Tests/Controllers/StopWordsControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StopWordsControllerTests.cs
@@ -110,7 +110,7 @@ public class StopWordsControllerTests
     public async Task GetStopWords_ReturnsAll_ForLogist()
     {
         SetCurrentUserId(2);
-        _dbContext.StopWord.AddRange(new StopWord { Id = 1, Word = "a" }, new StopWord { Id = 2, Word = "b" });
+        _dbContext.StopWords.AddRange(new StopWord { Id = 1, Word = "a" }, new StopWord { Id = 2, Word = "b" });
         await _dbContext.SaveChangesAsync();
 
         var result = await _controller.GetStopWords();
@@ -157,7 +157,7 @@ public class StopWordsControllerTests
         var reg = new Register { Id = 1, FileName = "r" };
         var order = new WbrOrder { Id = 1, RegisterId = 1 };
         var link = new BaseOrderStopWord { BaseOrderId = 1, StopWordId = 5, BaseOrder = order, StopWord = word };
-        _dbContext.StopWord.Add(word);
+        _dbContext.StopWords.Add(word);
         _dbContext.Registers.Add(reg);
         _dbContext.Orders.Add(order);
         _dbContext.Add(link);
@@ -167,7 +167,7 @@ public class StopWordsControllerTests
 
         Assert.That(result, Is.TypeOf<NoContentResult>());
         // Verify the link is also deleted
-        Assert.That(_dbContext.StopWord.Find(5), Is.Null);
+        Assert.That(_dbContext.StopWords.Find(5), Is.Null);
         Assert.That(_dbContext.Set<BaseOrderStopWord>().Any(x => x.StopWordId == 5), Is.False);
     }
 
@@ -176,7 +176,7 @@ public class StopWordsControllerTests
     {
         SetCurrentUserId(2);
         var word = new StopWord { Id = 6, Word = "find" };
-        _dbContext.StopWord.Add(word);
+        _dbContext.StopWords.Add(word);
         await _dbContext.SaveChangesAsync();
 
         var result = await _controller.GetStopWord(6);
@@ -190,7 +190,7 @@ public class StopWordsControllerTests
     {
         SetCurrentUserId(1); // Admin
         var existing = new StopWord { Id = 10, Word = "duplicate", ExactMatch = false };
-        _dbContext.StopWord.Add(existing);
+        _dbContext.StopWords.Add(existing);
         await _dbContext.SaveChangesAsync();
 
         var dto = new StopWordDto { Word = "duplicate", ExactMatch = false };
@@ -207,7 +207,7 @@ public class StopWordsControllerTests
         SetCurrentUserId(1); // Admin
         var word1 = new StopWord { Id = 11, Word = "first", ExactMatch = false };
         var word2 = new StopWord { Id = 12, Word = "second", ExactMatch = false };
-        _dbContext.StopWord.AddRange(word1, word2);
+        _dbContext.StopWords.AddRange(word1, word2);
         await _dbContext.SaveChangesAsync();
 
         var dto = new StopWordDto { Id = 11, Word = "second", ExactMatch = false };
@@ -224,7 +224,7 @@ public class StopWordsControllerTests
         // Arrange: create a stop word as admin
         SetCurrentUserId(1);
         var word = new StopWord { Id = 100, Word = "editme", ExactMatch = false };
-        _dbContext.StopWord.Add(word);
+        _dbContext.StopWords.Add(word);
         await _dbContext.SaveChangesAsync();
 
         // Act: try to update as non-admin
@@ -244,7 +244,7 @@ public class StopWordsControllerTests
         // Arrange: create a stop word as admin
         SetCurrentUserId(1);
         var word = new StopWord { Id = 101, Word = "deleteme", ExactMatch = false };
-        _dbContext.StopWord.Add(word);
+        _dbContext.StopWords.Add(word);
         await _dbContext.SaveChangesAsync();
 
         // Act: try to delete as non-admin

--- a/Logibooks.Core.Tests/Services/OrderValidationServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/OrderValidationServiceTests.cs
@@ -52,7 +52,7 @@ public class OrderValidationServiceTests
         using var ctx = CreateContext();
         var order = new WbrOrder { Id = 1, RegisterId = 1, CheckStatusId = 1, Description = "This is SPAM" };
         ctx.Orders.Add(order);
-        ctx.StopWord.AddRange(
+        ctx.StopWords.AddRange(
             new StopWord { Id = 2, Word = "spam", ExactMatch = true },
             new StopWord { Id = 3, Word = "other", ExactMatch = true }
         );
@@ -74,7 +74,7 @@ public class OrderValidationServiceTests
         using var ctx = CreateContext();
         var order = new WbrOrder { Id = 1, RegisterId = 1, CheckStatusId = 1, Description = "clean" };
         ctx.Orders.Add(order);
-        ctx.StopWord.Add(new StopWord { Id = 2, Word = "spam", ExactMatch = true });
+        ctx.StopWords.Add(new StopWord { Id = 2, Word = "spam", ExactMatch = true });
         await ctx.SaveChangesAsync();
 
         var svc = new OrderValidationService(ctx);
@@ -90,7 +90,7 @@ public class OrderValidationServiceTests
         using var ctx = CreateContext();
         var order = new WbrOrder { Id = 1, RegisterId = 1, CheckStatusId = 1, Description = "bad WORD" };
         ctx.Orders.Add(order);
-        ctx.StopWord.Add(new StopWord { Id = 5, Word = "word", ExactMatch = true });
+        ctx.StopWords.Add(new StopWord { Id = 5, Word = "word", ExactMatch = true });
         await ctx.SaveChangesAsync();
 
         var svc = new OrderValidationService(ctx);

--- a/Logibooks.Core/Controllers/StopWordsController.cs
+++ b/Logibooks.Core/Controllers/StopWordsController.cs
@@ -44,7 +44,7 @@ public class StopWordsController(
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<StopWordDto>))]
     public async Task<ActionResult<IEnumerable<StopWordDto>>> GetStopWords()
     {
-        var words = await _db.StopWord.AsNoTracking().OrderBy(w => w.Id).ToListAsync();
+        var words = await _db.StopWords.AsNoTracking().OrderBy(w => w.Id).ToListAsync();
         return words.Select(w => new StopWordDto(w)).ToList();
     }
 
@@ -53,7 +53,7 @@ public class StopWordsController(
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
     public async Task<ActionResult<StopWordDto>> GetStopWord(int id)
     {
-        var word = await _db.StopWord.AsNoTracking().FirstOrDefaultAsync(w => w.Id == id);
+        var word = await _db.StopWords.AsNoTracking().FirstOrDefaultAsync(w => w.Id == id);
         return word == null ? _404Object(id) : new StopWordDto(word);
     }
 
@@ -64,12 +64,12 @@ public class StopWordsController(
     public async Task<ActionResult<StopWordDto>> PostStopWord(StopWordDto dto)
     {
         if (!await _db.CheckAdmin(_curUserId)) return _403();
-        if (await _db.StopWord.AnyAsync(sw => sw.Word.ToLower() == dto.Word.ToLower()))
+        if (await _db.StopWords.AnyAsync(sw => sw.Word.ToLower() == dto.Word.ToLower()))
         {
             return _409StopWord(dto.Word);
         }
         var sw = dto.ToModel();
-        _db.StopWord.Add(sw);
+        _db.StopWords.Add(sw);
         try
         {
             await _db.SaveChangesAsync();
@@ -92,10 +92,10 @@ public class StopWordsController(
     {
         if (!await _db.CheckAdmin(_curUserId)) return _403();
         if (id != dto.Id) return BadRequest();
-        var sw = await _db.StopWord.FindAsync(id);
+        var sw = await _db.StopWords.FindAsync(id);
         if (sw == null) return _404Object(id);
         if (!sw.Word.Equals(dto.Word, StringComparison.OrdinalIgnoreCase) &&
-            await _db.StopWord.AnyAsync(w => w.Word.ToLower() == dto.Word.ToLower()))
+            await _db.StopWords.AnyAsync(w => w.Word.ToLower() == dto.Word.ToLower()))
         {
             return _409StopWord(dto.Word);
         }
@@ -122,10 +122,10 @@ public class StopWordsController(
     public async Task<IActionResult> DeleteStopWord(int id)
     {
         if (!await _db.CheckAdmin(_curUserId)) return _403();
-        var sw = await _db.StopWord.FindAsync(id);
+        var sw = await _db.StopWords.FindAsync(id);
         if (sw == null) return _404Object(id);
 
-        _db.StopWord.Remove(sw);
+        _db.StopWords.Remove(sw);
         await _db.SaveChangesAsync();
         return NoContent();
     }

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -45,7 +45,7 @@ namespace Logibooks.Core.Data
         public DbSet<OzonOrder> OzonOrders => Set<OzonOrder>();
         public DbSet<Country> Countries => Set<Country>();
         public DbSet<Company> Companies => Set<Company>();
-        public DbSet<StopWord> StopWord => Set<StopWord>();
+        public DbSet<StopWord> StopWords => Set<StopWord>();
         public async Task<bool> CheckAdmin(int cuid)
         {
             var user = await Users

--- a/Logibooks.Core/Services/OrderValidationService.cs
+++ b/Logibooks.Core/Services/OrderValidationService.cs
@@ -43,7 +43,7 @@ public class OrderValidationService(AppDbContext db) : IOrderValidationService
 
         var description = order.Description ?? string.Empty;
 
-        var words = await _db.StopWord.AsNoTracking()
+        var words = await _db.StopWords.AsNoTracking()
             .Where(sw => sw.ExactMatch)
             .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
## Summary
- rename `StopWord` DbSet to `StopWords`
- update controllers, services and unit tests

## Testing
- `dotnet test Logibooks.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877a04597a48321bb554953f7e8774a