### PR TITLE
Include stop words when fetching orders

### DIFF
--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -65,7 +65,10 @@ public class OrdersController(
             return _403();
         }
 
-        var order = await _db.Orders.AsNoTracking().FirstOrDefaultAsync(o => o.Id == id);
+        var order = await _db.Orders.AsNoTracking()
+            .Include(o => o.BaseOrderStopWords)
+                .ThenInclude(bosw => bosw.StopWord)
+            .FirstOrDefaultAsync(o => o.Id == id);
         if (order == null)
         {
             _logger.LogDebug("GetOrder returning '404 Not Found'");
@@ -154,7 +157,10 @@ public class OrdersController(
             return _403();
         }
 
-        IQueryable<BaseOrder> query = _db.Orders.AsNoTracking().Where(o => o.RegisterId == registerId);
+        IQueryable<BaseOrder> query = _db.Orders.AsNoTracking()
+            .Include(o => o.BaseOrderStopWords)
+                .ThenInclude(bosw => bosw.StopWord)
+            .Where(o => o.RegisterId == registerId);
 
         if (statusId != null)
         {

--- a/Logibooks.Core/RestModels/OrderViewItem.cs
+++ b/Logibooks.Core/RestModels/OrderViewItem.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Text.Json;
+using System.Linq;
 using Logibooks.Core.Models;
 using Logibooks.Core.Settings;
 
@@ -52,6 +53,7 @@ public class OrderViewItem
     public string? PassportNumber { get; set; }
     public string? PostingNumber { get; set; }
     public string? OzonId { get; set; }
+    public ICollection<StopWordDto> StopWords { get; set; } = new List<StopWordDto>();
     public OrderViewItem(BaseOrder order)
     {
         ArgumentNullException.ThrowIfNull(order);
@@ -82,6 +84,13 @@ public class OrderViewItem
         {
             PostingNumber = ozon.PostingNumber;
             OzonId = ozon.OzonId;
+        }
+
+        if (order.BaseOrderStopWords?.Any() == true)
+        {
+            StopWords = order.BaseOrderStopWords
+                .Select(bosw => new StopWordDto(bosw.StopWord))
+                .ToList();
         }
     }
 


### PR DESCRIPTION
## Summary
- extend `OrderViewItem` with `StopWords` collection
- return associated stop words in OrdersController's GET endpoints
- test that stop words are returned for single and multiple orders

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_6877a417357883219245e81f576b4571