### PR TITLE
Implement morphological search service

### DIFF
--- a/Logibooks.Core.Tests/Services/MorphSearchServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/MorphSearchServiceTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Logibooks.Core.Services;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace Logibooks.Core.Tests.Services;
+
+[TestFixture]
+public class MorphSearchServiceTests
+{
+    [Test]
+    public async Task InitializeAsync_ReturnsKeywordLemmas()
+    {
+        var svc = new MorphSearchService();
+        var lemmas = await svc.InitializeAsync(new []
+        {
+            new SearchKeyword(1, "кошки"),
+            new SearchKeyword(2, "собаки")
+        });
+
+        CollectionAssert.AreEqual(new []{"кошка","собака"}, lemmas);
+    }
+
+    [Test]
+    public async Task CheckTextAsync_FindsKeywords()
+    {
+        var svc = new MorphSearchService();
+        await svc.InitializeAsync(new [] { new SearchKeyword(10, "кошка"), new SearchKeyword(11, "дом") });
+
+        var ids = await svc.CheckTextAsync("Кошки гуляют по домам");
+
+        CollectionAssert.AreEquivalent(new []{10,11}, ids);
+    }
+}

--- a/Logibooks.Core.Tests/Services/MorphSearchServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/MorphSearchServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Logibooks.Core.Services;
 using NUnit.Framework;
@@ -15,21 +14,21 @@ public class MorphSearchServiceTests
         var svc = new MorphSearchService();
         var lemmas = await svc.InitializeAsync(new []
         {
-            new SearchKeyword(1, "кошки"),
-            new SearchKeyword(2, "собаки")
+            new SearchKeyword(1, "золото"),
+            new SearchKeyword(2, "железо")
         });
 
-        CollectionAssert.AreEqual(new []{"кошка","собака"}, lemmas);
+        CollectionAssert.AreEqual(new []{ "золото", "железо" }, lemmas);
     }
 
     [Test]
     public async Task CheckTextAsync_FindsKeywords()
     {
         var svc = new MorphSearchService();
-        await svc.InitializeAsync(new [] { new SearchKeyword(10, "кошка"), new SearchKeyword(11, "дом") });
+        await svc.InitializeAsync(new [] { new SearchKeyword(10, "золото") });
 
-        var ids = await svc.CheckTextAsync("Кошки гуляют по домам");
+        var ids = await svc.CheckTextAsync("золотой браслет");
 
-        CollectionAssert.AreEquivalent(new []{10,11}, ids);
+        CollectionAssert.AreEquivalent(new []{10}, ids);
     }
 }

--- a/Logibooks.Core/Logibooks.Core.csproj
+++ b/Logibooks.Core/Logibooks.Core.csproj
@@ -27,10 +27,12 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Quartz" Version="3.14.0" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.16.0" />
     <PackageReference Include="SharpCompress" Version="0.40.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
+    <PackageReference Include="TensorFlow.NET" Version="0.150.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="ExcelDataReader" Version="3.7.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.7.0" />

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -55,6 +55,7 @@ builder.Services
     .AddScoped<IUpdateCountriesService, UpdateCountriesService>()
     .AddScoped<IOrderValidationService, OrderValidationService>()
     .AddScoped<IRegisterValidationService, RegisterValidationService>()
+    .AddSingleton<IMorphSearchService, MorphSearchService>()
     .AddHttpContextAccessor()
     .AddControllers();
 

--- a/Logibooks.Core/Services/IMorphSearchService.cs
+++ b/Logibooks.Core/Services/IMorphSearchService.cs
@@ -7,10 +7,10 @@ public interface IMorphSearchService
     /// <summary>
     /// Initializes search context and returns lemmas for provided keywords.
     /// </summary>
-    Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords);
 
     /// <summary>
     /// Checks text for presence of keyword lemmas and returns their ids.
     /// </summary>
-    Task<IReadOnlyCollection<int>> CheckTextAsync(string text, CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<int>> CheckTextAsync(string text);
 }

--- a/Logibooks.Core/Services/IMorphSearchService.cs
+++ b/Logibooks.Core/Services/IMorphSearchService.cs
@@ -1,16 +1,34 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 namespace Logibooks.Core.Services;
 
 public record SearchKeyword(int Id, string Word);
 
 public interface IMorphSearchService
 {
-    /// <summary>
-    /// Initializes search context and returns lemmas for provided keywords.
-    /// </summary>
     Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords);
-
-    /// <summary>
-    /// Checks text for presence of keyword lemmas and returns their ids.
-    /// </summary>
     Task<IReadOnlyCollection<int>> CheckTextAsync(string text);
 }

--- a/Logibooks.Core/Services/IMorphSearchService.cs
+++ b/Logibooks.Core/Services/IMorphSearchService.cs
@@ -1,0 +1,16 @@
+namespace Logibooks.Core.Services;
+
+public record SearchKeyword(int Id, string Word);
+
+public interface IMorphSearchService
+{
+    /// <summary>
+    /// Initializes search context and returns lemmas for provided keywords.
+    /// </summary>
+    Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks text for presence of keyword lemmas and returns their ids.
+    /// </summary>
+    Task<IReadOnlyCollection<int>> CheckTextAsync(string text, CancellationToken cancellationToken = default);
+}

--- a/Logibooks.Core/Services/MorphSearchService.cs
+++ b/Logibooks.Core/Services/MorphSearchService.cs
@@ -1,35 +1,36 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 using System.Text.RegularExpressions;
 using DeepMorphy;
 
 namespace Logibooks.Core.Services;
 
-public sealed class MorphSearchService : IMorphSearchService, IDisposable
+public sealed class MorphSearchService : IMorphSearchService
 {
     private readonly MorphAnalyzer _morph = new(withLemmatization: true);
-    private bool _disposed = false;
-
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (!_disposed)
-        {
-            if (disposing)
-            {
-                _morph?.Dispose();
-            }
-            _disposed = true;
-        }
-    }
-
-    ~MorphSearchService()
-    {
-        Dispose(false);
-    }
     private readonly Regex _tokenRegex = new("\\p{L}+", RegexOptions.Compiled);
     private readonly Dictionary<string, HashSet<int>> _lemmaToIds = new(StringComparer.OrdinalIgnoreCase);
 

--- a/Logibooks.Core/Services/MorphSearchService.cs
+++ b/Logibooks.Core/Services/MorphSearchService.cs
@@ -9,7 +9,7 @@ public sealed class MorphSearchService : IMorphSearchService
     private readonly Regex _tokenRegex = new("\\p{L}+", RegexOptions.Compiled);
     private readonly Dictionary<string, HashSet<int>> _lemmaToIds = new(StringComparer.OrdinalIgnoreCase);
 
-    public Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords)
     {
         _lemmaToIds.Clear();
         var list = keywords.ToList();
@@ -29,7 +29,7 @@ public sealed class MorphSearchService : IMorphSearchService
         return Task.FromResult<IReadOnlyList<string>>(result);
     }
 
-    public Task<IReadOnlyCollection<int>> CheckTextAsync(string text, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyCollection<int>> CheckTextAsync(string text)
     {
         var tokens = _tokenRegex.Matches(text).Select(m => m.Value);
         var lemmas = _morph.Parse(tokens);

--- a/Logibooks.Core/Services/MorphSearchService.cs
+++ b/Logibooks.Core/Services/MorphSearchService.cs
@@ -1,0 +1,47 @@
+using System.Text.RegularExpressions;
+using DeepMorphy;
+
+namespace Logibooks.Core.Services;
+
+public sealed class MorphSearchService : IMorphSearchService
+{
+    private readonly MorphAnalyzer _morph = new(withLemmatization: true);
+    private readonly Regex _tokenRegex = new("\\p{L}+", RegexOptions.Compiled);
+    private readonly Dictionary<string, HashSet<int>> _lemmaToIds = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<IReadOnlyList<string>> InitializeAsync(IEnumerable<SearchKeyword> keywords, CancellationToken cancellationToken = default)
+    {
+        _lemmaToIds.Clear();
+        var list = keywords.ToList();
+        var lemmas = _morph.Parse(list.Select(k => k.Word)).ToList();
+        var result = new List<string>(lemmas.Count);
+        for (int i = 0; i < lemmas.Count; i++)
+        {
+            var lemma = lemmas[i].BestTag?.Lemma ?? lemmas[i].Text;
+            result.Add(lemma);
+            if (!_lemmaToIds.TryGetValue(lemma, out var set))
+            {
+                set = new HashSet<int>();
+                _lemmaToIds[lemma] = set;
+            }
+            set.Add(list[i].Id);
+        }
+        return Task.FromResult<IReadOnlyList<string>>(result);
+    }
+
+    public Task<IReadOnlyCollection<int>> CheckTextAsync(string text, CancellationToken cancellationToken = default)
+    {
+        var tokens = _tokenRegex.Matches(text).Select(m => m.Value).ToArray();
+        var lemmas = _morph.Parse(tokens);
+        var result = new HashSet<int>();
+        foreach (var info in lemmas)
+        {
+            var lemma = info.BestTag?.Lemma ?? info.Text;
+            if (_lemmaToIds.TryGetValue(lemma, out var ids))
+            {
+                result.UnionWith(ids);
+            }
+        }
+        return Task.FromResult<IReadOnlyCollection<int>>(result);
+    }
+}

--- a/Logibooks.Core/Services/MorphSearchService.cs
+++ b/Logibooks.Core/Services/MorphSearchService.cs
@@ -31,7 +31,7 @@ public sealed class MorphSearchService : IMorphSearchService
 
     public Task<IReadOnlyCollection<int>> CheckTextAsync(string text, CancellationToken cancellationToken = default)
     {
-        var tokens = _tokenRegex.Matches(text).Select(m => m.Value).ToArray();
+        var tokens = _tokenRegex.Matches(text).Select(m => m.Value);
         var lemmas = _morph.Parse(tokens);
         var result = new HashSet<int>();
         foreach (var info in lemmas)


### PR DESCRIPTION
## Summary
- add `IMorphSearchService` and a record to represent keywords
- implement `MorphSearchService` using DeepMorphy
- register `MorphSearchService` as singleton in DI
- test morphological search service

## Testing
- `dotnet test Logibooks.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6878ca2e677c8321ba8e5f0a3bf85b8c