### PR TITLE
Implement morphology search service

### DIFF
--- a/Logibooks.Core.Tests/Services/MorphologySearchServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/MorphologySearchServiceTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using System.Linq;
+using Logibooks.Core.Models;
+using Logibooks.Core.Services;
+
+namespace Logibooks.Core.Tests.Services;
+
+[TestFixture]
+public class MorphologySearchServiceTests
+{
+    [Test]
+    public void CheckText_FindsDerivativeMatch()
+    {
+        var svc = new MorphologySearchService();
+        var sw = new StopWord { Id = 1, Word = "золото" };
+        var ctx = svc.InitializeContext(new[] { sw });
+        var res = svc.CheckText(ctx, "золотой браслет и алюминиевый слиток");
+        Assert.That(res.Contains(1));
+    }
+}

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -55,6 +55,7 @@ builder.Services
     .AddScoped<IUpdateCountriesService, UpdateCountriesService>()
     .AddScoped<IOrderValidationService, OrderValidationService>()
     .AddScoped<IRegisterValidationService, RegisterValidationService>()
+    .AddSingleton<IMorphologySearchService, MorphologySearchService>()
     .AddHttpContextAccessor()
     .AddControllers();
 

--- a/Logibooks.Core/Services/IMorphologySearchService.cs
+++ b/Logibooks.Core/Services/IMorphologySearchService.cs
@@ -1,0 +1,15 @@
+namespace Logibooks.Core.Services;
+
+using System.Collections.Generic;
+using Logibooks.Core.Models;
+
+public interface IMorphologySearchService
+{
+    MorphologyContext InitializeContext(IEnumerable<StopWord> stopWords);
+    IEnumerable<int> CheckText(MorphologyContext context, string text);
+}
+
+public class MorphologyContext
+{
+    internal Dictionary<Pullenti.Semantic.Utils.DerivateGroup, HashSet<int>> Groups { get; } = new();
+}

--- a/Logibooks.Core/Services/MorphologySearchService.cs
+++ b/Logibooks.Core/Services/MorphologySearchService.cs
@@ -1,0 +1,56 @@
+namespace Logibooks.Core.Services;
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Pullenti.Morph;
+using Pullenti.Semantic.Utils;
+using Logibooks.Core.Models;
+
+public class MorphologySearchService : IMorphologySearchService
+{
+    static MorphologySearchService()
+    {
+        MorphologyService.Initialize(Pullenti.Morph.MorphLang.RU);
+        DerivateService.Initialize(Pullenti.Morph.MorphLang.RU);
+    }
+
+    public MorphologyContext InitializeContext(IEnumerable<StopWord> stopWords)
+    {
+        var context = new MorphologyContext();
+        foreach (var sw in stopWords)
+        {
+            if (string.IsNullOrWhiteSpace(sw.Word))
+                continue;
+            var groups = DerivateService.FindDerivates(sw.Word.ToUpperInvariant(), true, null);
+            if (groups == null)
+                continue;
+            foreach (var g in groups)
+            {
+                if (!context.Groups.TryGetValue(g, out var ids))
+                {
+                    ids = new HashSet<int>();
+                    context.Groups[g] = ids;
+                }
+                ids.Add(sw.Id);
+            }
+        }
+        return context;
+    }
+
+    public IEnumerable<int> CheckText(MorphologyContext context, string text)
+    {
+        var result = new HashSet<int>();
+        foreach (Match m in Regex.Matches(text ?? string.Empty, @"\p{L}+"))
+        {
+            var tokenGroups = DerivateService.FindDerivates(m.Value.ToUpperInvariant(), true, null);
+            if (tokenGroups == null)
+                continue;
+            foreach (var g in tokenGroups)
+            {
+                if (context.Groups.TryGetValue(g, out var ids))
+                    result.UnionWith(ids);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- implement morphological search service using Pullenti
- register the service as singleton in DI container
- add NUnit tests for morphological search

## Testing
- `dotnet test Logibooks.sln -v minimal` *(fails: StartValidationAsync_SetsError_WhenScopedServicesNotResolved)*
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj --filter "FullyQualifiedName~MorphologySearchServiceTests" -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687900a366f0832199c8801a0e130fd6