### PR TITLE
Extend FEACN code parsing

### DIFF
--- a/Logibooks.Core.Tests/Services/UpdateFeacnCodesServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/UpdateFeacnCodesServiceTests.cs
@@ -527,7 +527,7 @@ public class UpdateFeacnCodesServiceTests
 
         var htmlContent = @"
             <table>
-                <tr><td>12 34, 56 78 (кроме 90 12, 34 56)</td><td>Product</td></tr>
+                <tr><td>12 34, 56 78 (кроме 1234 90 12, 567834 56)</td><td>Product</td></tr>
             </table>";
 
         SetupHttpResponse("https://www.alta.ru/tamdoc/test-url/", htmlContent);
@@ -548,7 +548,7 @@ public class UpdateFeacnCodesServiceTests
         foreach (var prefix in prefixes)
         {
             var exc = prefix.FeacnPrefixExceptions.Select(e => e.Code).OrderBy(c => c).ToList();
-            CollectionAssert.AreEquivalent(new[] { "9012", "3456" }, exc);
+            Assert.That(exc, Is.EquivalentTo(["12349012", "56783456"]));
         }
     }
 

--- a/Logibooks.Core/Services/UpdateFeacnCodesService.cs
+++ b/Logibooks.Core/Services/UpdateFeacnCodesService.cs
@@ -181,11 +181,16 @@ public class UpdateFeacnCodesService(
         @"\((?:за\s+исключением|кроме)\s+(.*?)\)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    private static readonly Regex WhitespaceRegex = new(
+        @"\s+",
+        RegexOptions.Compiled);
+
+
     private static IEnumerable<string> ParseCodes(string codes)
     {
         return codes
             .Split(',', StringSplitOptions.RemoveEmptyEntries)
-            .Select(c => Regex.Replace(c, "\\s+", string.Empty))
+            .Select(c => WhitespaceRegex.Replace(c, string.Empty))
             .Where(c => !string.IsNullOrWhiteSpace(c));
     }
     private async Task<List<FeacnCodeRow>> ExtractAsync(CancellationToken token)
@@ -273,7 +278,7 @@ public class UpdateFeacnCodesService(
 
                     foreach (var single in ParseCodes(code))
                     {
-                        if (string.IsNullOrWhiteSpace(single)) continue;
+                        // ParseCodes method already filters out empty entries with Where(c => !string.IsNullOrWhiteSpace(c)) 
                         result.Add(new FeacnCodeRow(order.Id, single, name, comment, exceptions));
                     }
                 }
@@ -283,7 +288,7 @@ public class UpdateFeacnCodesService(
         return result;
     }
 
-    private record FeacnCodeRow(int OrderId, string Code, string Name, string Comment, List<string> Exceptions);
+    private record FeacnCodeRow(int OrderId, string Code, string Name, string Comment, IReadOnlyList<string> Exceptions);
 
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {

--- a/Logibooks.Core/Services/UpdateFeacnCodesService.cs
+++ b/Logibooks.Core/Services/UpdateFeacnCodesService.cs
@@ -176,6 +176,18 @@ public class UpdateFeacnCodesService(
             ?.Select(c => (HtmlEntity.DeEntitize(c.InnerText) ?? string.Empty).Trim())
             .ToArray();
     }
+
+    private static readonly Regex ExceptionRegex = new(
+        @"\((?:за\s+исключением|кроме)\s+(.*?)\)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static IEnumerable<string> ParseCodes(string codes)
+    {
+        return codes
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(c => Regex.Replace(c, "\\s+", string.Empty))
+            .Where(c => !string.IsNullOrWhiteSpace(c));
+    }
     private async Task<List<FeacnCodeRow>> ExtractAsync(CancellationToken token)
     {
         var result = new List<FeacnCodeRow>();
@@ -251,7 +263,19 @@ public class UpdateFeacnCodesService(
                     // Skip if code becomes empty after cleaning
                     if (string.IsNullOrWhiteSpace(code)) continue;
 
-                    result.Add(new FeacnCodeRow(order.Id, code, name, comment));
+                    var excMatch = ExceptionRegex.Match(code);
+                    List<string> exceptions = [];
+                    if (excMatch.Success)
+                    {
+                        exceptions = ParseCodes(excMatch.Groups[1].Value).ToList();
+                        code = code.Remove(excMatch.Index, excMatch.Length).Trim();
+                    }
+
+                    foreach (var single in ParseCodes(code))
+                    {
+                        if (string.IsNullOrWhiteSpace(single)) continue;
+                        result.Add(new FeacnCodeRow(order.Id, single, name, comment, exceptions));
+                    }
                 }
             }
         }
@@ -259,7 +283,7 @@ public class UpdateFeacnCodesService(
         return result;
     }
 
-    private record FeacnCodeRow(int OrderId, string Code, string Name, string Comment);
+    private record FeacnCodeRow(int OrderId, string Code, string Name, string Comment, List<string> Exceptions);
 
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
@@ -291,13 +315,22 @@ public class UpdateFeacnCodesService(
             }
 
             // Add new prefixes using batch operation
-            var newPrefixes = extracted.Select(row => new FeacnPrefix
+            var newPrefixes = new List<FeacnPrefix>();
+
+            foreach (var row in extracted)
             {
-                FeacnOrderId = row.OrderId,
-                Code = row.Code,
-                Description = row.Name,
-                Comment = row.Comment
-            }).ToList();
+                var prefix = new FeacnPrefix
+                {
+                    FeacnOrderId = row.OrderId,
+                    Code = row.Code,
+                    Description = row.Name,
+                    Comment = row.Comment,
+                    FeacnPrefixExceptions = row.Exceptions
+                        .Select(e => new FeacnPrefixException { Code = e })
+                        .ToList()
+                };
+                newPrefixes.Add(prefix);
+            }
 
             _db.FeacnPrefixes.AddRange(newPrefixes);
             _logger.LogInformation("Adding {Count} new FEACN prefixes", newPrefixes.Count);


### PR DESCRIPTION
## Summary
- parse FEACN code column for exceptions and multiple codes
- generate `FeacnPrefixException` entities
- test FEACN exception parsing

## Testing
- `dotnet test --no-build --verbosity minimal Logibooks.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2903caa88321a8958d9a243c3d30