### PR TITLE
Add UpdateFeacnCodesService tests

### DIFF
--- a/Logibooks.Core/Services/UpdateFeacnCodesService.cs
+++ b/Logibooks.Core/Services/UpdateFeacnCodesService.cs
@@ -210,7 +210,7 @@ public class UpdateFeacnCodesService(
     private static IEnumerable<string> ParseCodes(string codes)
     {
         var results = codes
-            .Split([',', 'и', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Split(new[] { ',', 'и', '\n' }, StringSplitOptions.RemoveEmptyEntries)
             .Select(c => WhitespaceRegex.Replace(c, string.Empty))
             .Where(c => !string.IsNullOrWhiteSpace(c))
             .Where(c => Regex.IsMatch(c, @"^\d+$"));


### PR DESCRIPTION
## Summary
- avoid ambiguous Split call in UpdateFeacnCodesService
- add tests for known-header skipping
- test government phrase warning
- verify merging exceptions for duplicate codes
- ensure editorial patterns are cleaned

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b57f4830883218173b7e47af5dd56