### PR TITLE
Implement FEACN prefix context generation

### DIFF
--- a/Logibooks.Core/Services/FeacnPrefixCheckService.cs
+++ b/Logibooks.Core/Services/FeacnPrefixCheckService.cs
@@ -77,11 +77,8 @@ public class FeacnPrefixCheckService(AppDbContext db) : IFeacnPrefixCheckService
         foreach (var prefix in prefixes)
         {
             var key = prefix.Code[..2];
-            if (!context.Prefixes.TryGetValue(key, out var list))
-            {
-                list = new List<FeacnPrefix>();
-                context.Prefixes[key] = list;
-            }
+            var list = context.Prefixes.GetValueOrDefault(key) ?? new List<FeacnPrefix>();
+            context.Prefixes[key] = list;
             list.Add(prefix);
         }
 

--- a/Logibooks.Core/Services/IFeacnPrefixCheckService.cs
+++ b/Logibooks.Core/Services/IFeacnPrefixCheckService.cs
@@ -30,4 +30,10 @@ namespace Logibooks.Core.Services;
 public interface IFeacnPrefixCheckService
 {
     Task<IEnumerable<BaseOrderFeacnPrefix>> CheckOrderAsync(BaseOrder order, CancellationToken cancellationToken = default);
+    Task<FeacnPrefixCheckContext> CreateContext(CancellationToken cancellationToken = default);
+}
+
+public class FeacnPrefixCheckContext
+{
+    internal Dictionary<string, List<FeacnPrefix>> Prefixes { get; } = new();
 }


### PR DESCRIPTION
## Summary
- extend `IFeacnPrefixCheckService` with `CreateContext`
- implement context creation in `FeacnPrefixCheckService`
- cover new behaviour with tests

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687c064c71148321bc9951738d031308