### PR TITLE
Implement context-based FEACN checks

### DIFF
--- a/Logibooks.Core/Services/IFeacnPrefixCheckService.cs
+++ b/Logibooks.Core/Services/IFeacnPrefixCheckService.cs
@@ -30,6 +30,7 @@ namespace Logibooks.Core.Services;
 public interface IFeacnPrefixCheckService
 {
     Task<IEnumerable<BaseOrderFeacnPrefix>> CheckOrderAsync(BaseOrder order, CancellationToken cancellationToken = default);
+    Task<IEnumerable<BaseOrderFeacnPrefix>> CheckOrderWithContextAsync(BaseOrder order, FeacnPrefixCheckContext context, CancellationToken cancellationToken = default);
     Task<FeacnPrefixCheckContext> CreateContext(CancellationToken cancellationToken = default);
 }
 


### PR DESCRIPTION
## Summary
- add `CheckOrderWithContextAsync` to `IFeacnPrefixCheckService`
- implement new method in `FeacnPrefixCheckService`
- test `CheckOrderWithContextAsync` in FeacnPrefixCheckService tests

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_687c0eeab6908321ba8eaacfb6d61162