### PR TITLE
Implement FEACN prefix validation

### DIFF
--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -565,15 +565,18 @@ public class OrdersControllerTests
         var order = new WbrOrder { Id = 10, RegisterId = 10, StatusId = 1 };
         _dbContext.Registers.Add(register);
         _dbContext.Orders.Add(order);
+        _dbContext.FeacnOrders.Add(new FeacnOrder { Id = 1, Title = "t" });
+        _dbContext.FeacnPrefixes.Add(new FeacnPrefix { Id = 1, Code = "12", FeacnOrderId = 1 });
         await _dbContext.SaveChangesAsync();
 
         var result = await _controller.ValidateOrder(10);
 
         _mockValidationService.Verify(s => s.ValidateAsync(
-            order, 
+            order,
             It.IsAny<MorphologyContext?>(),
             It.IsAny<StopWordsContext?>(),
-            It.IsAny<CancellationToken>()), 
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
             Times.Once);
         Assert.That(result, Is.TypeOf<NoContentResult>());
     }
@@ -588,7 +591,8 @@ public class OrdersControllerTests
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext?>(),
             It.IsAny<StopWordsContext?>(),
-            It.IsAny<CancellationToken>()), 
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
             Times.Never);
         Assert.That(result, Is.TypeOf<ObjectResult>());
         var obj = result as ObjectResult;
@@ -608,7 +612,8 @@ public class OrdersControllerTests
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext?>(),
             It.IsAny<StopWordsContext?>(),
-            It.IsAny<CancellationToken>()), 
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
             Times.Never);
     }
 }

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -249,7 +249,14 @@ public class OrdersController(
             .Where(sw => !sw.ExactMatch)
             .ToListAsync();
         var context = _morphologyService.InitializeContext(stopWords);
-        await _validationService.ValidateAsync(order, context, null);
+
+        var prefixes = await _db.FeacnPrefixes
+            .AsNoTracking()
+            .Include(p => p.FeacnPrefixExceptions)
+            .ToListAsync();
+        var feacnContext = _validationService.InitializeFeacnPrefixCheckContext(prefixes);
+
+        await _validationService.ValidateAsync(order, context, null, feacnContext);
 
         return NoContent();
     }

--- a/Logibooks.Core/Services/IOrderValidationService.cs
+++ b/Logibooks.Core/Services/IOrderValidationService.cs
@@ -35,12 +35,19 @@ public interface IOrderValidationService
     Task ValidateAsync(BaseOrder order,
         MorphologyContext? morphologyContext = null,
         StopWordsContext? stopWordsContext = null,
+        FeacnPrefixCheckContext? feacnPrefixContext = null,
         CancellationToken cancellationToken = default);
 
     StopWordsContext InitializeStopWordsContext(IEnumerable<StopWord> exactMatchStopWords);
+    FeacnPrefixCheckContext InitializeFeacnPrefixCheckContext(IEnumerable<FeacnPrefix> prefixes);
 }
 
 public class StopWordsContext
 {
     internal List<StopWord> ExactMatchStopWords { get; } = new();
+}
+
+public class FeacnPrefixCheckContext
+{
+    internal List<FeacnPrefix> Prefixes { get; } = new();
 }


### PR DESCRIPTION
## Summary
- extend `IOrderValidationService` with FEACN prefix check support
- update `OrderValidationService` to validate FEACN prefixes
- load prefix context in `RegisterValidationService` and `OrdersController`
- adjust unit tests for new parameter and add FEACN prefix checks

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1259e11c8321a40d62a5c70b3beb