### PR TITLE
Add Ozon fields to OrderViewItem

### DIFF
--- a/Logibooks.Core/RestModels/OrderViewItem.cs
+++ b/Logibooks.Core/RestModels/OrderViewItem.cs
@@ -51,6 +51,11 @@ public class OrderViewItem
     public string? RecipientName { get; set; }
     public string? RecipientInn { get; set; }
     public string? PassportNumber { get; set; }
+    public int? PlacesCount { get; set; }
+    public string? Article { get; set; }
+    public string? LastName { get; set; }
+    public string? FirstName { get; set; }
+    public string? Patronymic { get; set; }
     public string? PostingNumber { get; set; }
     public string? OzonId { get; set; }
     public List<int> StopWordIds { get; set; } = new();
@@ -84,6 +89,18 @@ public class OrderViewItem
         {
             PostingNumber = ozon.PostingNumber;
             OzonId = ozon.OzonId;
+            Country = ozon.Country;
+            WeightKg = ozon.WeightKg;
+            Quantity = ozon.Quantity;
+            UnitPrice = ozon.UnitPrice;
+            Currency = ozon.Currency;
+            ProductLink = ozon.ProductLink;
+            PassportNumber = ozon.PassportNumber;
+            PlacesCount = ozon.PlacesCount;
+            Article = ozon.Article;
+            LastName = ozon.LastName;
+            FirstName = ozon.FirstName;
+            Patronymic = ozon.Patronymic;
         }
 
         StopWordIds = order.BaseOrderStopWords?


### PR DESCRIPTION
## Summary
- extend `OrderViewItem` model with Ozon-specific properties
- populate these fields when converting an `OzonOrder`
- all tests continue to pass

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_687d4bb4d824832187542b9ca1afcd1a