### PR TITLE
Support company-specific order actions

### DIFF
--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -43,6 +43,18 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
                return StatusCode(StatusCodes.Status400BadRequest,
                           new ErrMessage() { Msg = $"Неизвестный идентификатор компании [id={companyId}]" });
     }
+
+    protected ObjectResult _400CompanyId()
+    {
+        return StatusCode(StatusCodes.Status400BadRequest,
+                          new ErrMessage() { Msg = "Не указан идентификатор компании" });
+    }
+
+    protected ObjectResult _404CompanyId(int companyId)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage() { Msg = $"Неизвестный идентификатор компании [id={companyId}]" });
+    }
     protected ObjectResult _400EmptyRegister()
     {
         return StatusCode(StatusCodes.Status400BadRequest,

--- a/Logibooks.Core/Extensions/OrderExtensions.cs
+++ b/Logibooks.Core/Extensions/OrderExtensions.cs
@@ -31,7 +31,12 @@ namespace Logibooks.Core.Extensions;
 
 public static class OrderExtensions
 {
-public static void UpdateFrom(this WbrOrder order, OrderUpdateItem updateItem, IMapper mapper)
+    public static void UpdateFrom(this WbrOrder order, OrderUpdateItem updateItem, IMapper mapper)
+    {
+        mapper.Map(updateItem, order);
+    }
+
+    public static void UpdateFrom(this OzonOrder order, OrderUpdateItem updateItem, IMapper mapper)
     {
         mapper.Map(updateItem, order);
     }

--- a/Logibooks.Core/Extensions/OrderMappingProfile.cs
+++ b/Logibooks.Core/Extensions/OrderMappingProfile.cs
@@ -39,6 +39,13 @@ public class OrderMappingProfile : Profile
             .ForMember(dest => dest.Register, opt => opt.Ignore())
             .ForMember(dest => dest.ProductName, opt => opt.MapFrom(src => src.ProductName))
             .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
+
+        CreateMap<OrderUpdateItem, OzonOrder>()
+            .ForMember(dest => dest.Id, opt => opt.Ignore())
+            .ForMember(dest => dest.RegisterId, opt => opt.Ignore())
+            .ForMember(dest => dest.Register, opt => opt.Ignore())
+            .ForMember(dest => dest.ProductName, opt => opt.MapFrom(src => src.ProductName))
+            .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
     }
 }
 


### PR DESCRIPTION
## Summary
- allow OrdersController endpoints to pick records based on company id
- support update & delete for ozon and wbr orders
- add helper responses for missing/unknown company id
- map update item to OzonOrder and extension method
- adjust unit tests for new company id requirement and add coverage

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_687d6bb1b030832188a59122a947230d