### PR TITLE
Add TransportationType controller and tests

### DIFF
--- a/Logibooks.Core.Tests/Controllers/TransportationTypesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/TransportationTypesControllerTests.cs
@@ -1,0 +1,133 @@
+using Logibooks.Core.Controllers;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Logibooks.Core.Tests.Controllers;
+
+[TestFixture]
+public class TransportationTypesControllerTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private ILogger<TransportationTypesController> _logger;
+    private TransportationTypesController _controller;
+    private Role _adminRole;
+    private Role _logistRole;
+    private User _adminUser;
+    private User _logistUser;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"tt_controller_db_{System.Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { Id = 1, Name = "administrator", Title = "Администратор" };
+        _logistRole = new Role { Id = 2, Name = "logist", Title = "Логист" };
+        _dbContext.Roles.AddRange(_adminRole, _logistRole);
+
+        string hpw = BCrypt.Net.BCrypt.HashPassword("pwd");
+        _adminUser = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = hpw,
+            UserRoles = [new UserRole { UserId = 1, RoleId = 1, Role = _adminRole }]
+        };
+        _logistUser = new User
+        {
+            Id = 2,
+            Email = "logist@example.com",
+            Password = hpw,
+            UserRoles = [new UserRole { UserId = 2, RoleId = 2, Role = _logistRole }]
+        };
+        _dbContext.Users.AddRange(_adminUser, _logistUser);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _logger = new LoggerFactory().CreateLogger<TransportationTypesController>();
+        _controller = new TransportationTypesController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    private void SetCurrentUserId(int id)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Items["UserId"] = id;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
+        _controller = new TransportationTypesController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+    }
+
+    [Test]
+    public async Task GetTypes_ReturnsAll()
+    {
+        SetCurrentUserId(2);
+        _dbContext.TransportationTypes.AddRange(
+            new TransportationType { Id = 1, Code = TransportationTypeCode.Avia, Name = "A" },
+            new TransportationType { Id = 2, Code = TransportationTypeCode.Auto, Name = "B" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetTypes();
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetType_ReturnsRecord_WhenExists()
+    {
+        SetCurrentUserId(2);
+        var tt = new TransportationType { Id = 10, Code = TransportationTypeCode.Auto, Name = "Auto" };
+        _dbContext.TransportationTypes.Add(tt);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetType(10);
+
+        Assert.That(result.Value, Is.Not.Null);
+        var dto = result.Value!;
+        Assert.That(dto.Id, Is.EqualTo(10));
+        Assert.That(dto.Code, Is.EqualTo(TransportationTypeCode.Auto));
+        Assert.That(dto.Name, Is.EqualTo("Auto"));
+    }
+
+    [Test]
+    public async Task GetType_ReturnsNotFound_WhenMissing()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.GetType(5);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task GetTypes_ReturnsEmptyList_WhenNoneExist()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.GetTypes();
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(0));
+    }
+}

--- a/Logibooks.Core.Tests/Controllers/TransportationTypesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/TransportationTypesControllerTests.cs
@@ -1,15 +1,37 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 using Logibooks.Core.Controllers;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
-using Logibooks.Core.RestModels;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
-using NUnit.Framework.Legacy;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/Logibooks.Core/Controllers/TransportationTypesController.cs
+++ b/Logibooks.Core/Controllers/TransportationTypesController.cs
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/Logibooks.Core/Controllers/TransportationTypesController.cs
+++ b/Logibooks.Core/Controllers/TransportationTypesController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using Logibooks.Core.Authorization;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+
+namespace Logibooks.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+[ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrMessage))]
+public class TransportationTypesController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    ILogger<TransportationTypesController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<TransportationTypeDto>))]
+    public async Task<ActionResult<IEnumerable<TransportationTypeDto>>> GetTypes()
+    {
+        var list = await _db.TransportationTypes.AsNoTracking().OrderBy(t => t.Id).ToListAsync();
+        return list.Select(t => new TransportationTypeDto(t)).ToList();
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TransportationTypeDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<TransportationTypeDto>> GetType(int id)
+    {
+        var type = await _db.TransportationTypes.AsNoTracking().FirstOrDefaultAsync(t => t.Id == id);
+        return type == null ? _404Object(id) : new TransportationTypeDto(type);
+    }
+}

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -48,6 +48,7 @@ namespace Logibooks.Core.Data
         public DbSet<FeacnOrder> FeacnOrders => Set<FeacnOrder>();
         public DbSet<FeacnPrefix> FeacnPrefixes => Set<FeacnPrefix>();
         public DbSet<FeacnPrefixException> FeacnPrefixExceptions => Set<FeacnPrefixException>();
+        public DbSet<TransportationType> TransportationTypes => Set<TransportationType>();
         public DbSet<BaseOrderFeacnPrefix> BaseOrderFeacnPrefixes => Set<BaseOrderFeacnPrefix>();
         public async Task<bool> CheckAdmin(int cuid)
         {
@@ -313,6 +314,11 @@ namespace Logibooks.Core.Data
                     City = "д. Коледино",
                     Street = "Индустриальный Парк Коледино, д.6, стр.1"
                 }
+            );
+
+            modelBuilder.Entity<TransportationType>().HasData(
+                new TransportationType { Id = 1, Code = TransportationTypeCode.Avia, Name = "Авиа" },
+                new TransportationType { Id = 2, Code = TransportationTypeCode.Auto, Name = "Авто" }
             );
 
             modelBuilder.Entity<UserRole>().HasData(

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -48,8 +48,8 @@ namespace Logibooks.Core.Data
         public DbSet<FeacnOrder> FeacnOrders => Set<FeacnOrder>();
         public DbSet<FeacnPrefix> FeacnPrefixes => Set<FeacnPrefix>();
         public DbSet<FeacnPrefixException> FeacnPrefixExceptions => Set<FeacnPrefixException>();
-        public DbSet<TransportationType> TransportationTypes => Set<TransportationType>();
         public DbSet<BaseOrderFeacnPrefix> BaseOrderFeacnPrefixes => Set<BaseOrderFeacnPrefix>();
+        public DbSet<TransportationType> TransportationTypes => Set<TransportationType>();
         public async Task<bool> CheckAdmin(int cuid)
         {
             var user = await Users

--- a/Logibooks.Core/Models/TransportationType.cs
+++ b/Logibooks.Core/Models/TransportationType.cs
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Logibooks.Core.Models;
@@ -8,7 +33,7 @@ public class TransportationType
     [Column("id")]
     public int Id { get; set; }
 
-    [Column("code", TypeName = "numeric(1)")]
+    [Column("code", TypeName = "numeric(2)")]
     public TransportationTypeCode Code { get; set; }
 
     [Column("name")]

--- a/Logibooks.Core/Models/TransportationType.cs
+++ b/Logibooks.Core/Models/TransportationType.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Logibooks.Core.Models;
+
+[Table("transportation_types")]
+public class TransportationType
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("code", TypeName = "numeric(1)")]
+    public TransportationTypeCode Code { get; set; }
+
+    [Column("name")]
+    public required string Name { get; set; }
+}

--- a/Logibooks.Core/Models/TransportationTypeCode.cs
+++ b/Logibooks.Core/Models/TransportationTypeCode.cs
@@ -1,0 +1,7 @@
+namespace Logibooks.Core.Models;
+
+public enum TransportationTypeCode
+{
+    Avia = 0,
+    Auto = 1
+}

--- a/Logibooks.Core/Models/TransportationTypeCode.cs
+++ b/Logibooks.Core/Models/TransportationTypeCode.cs
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 namespace Logibooks.Core.Models;
 
 public enum TransportationTypeCode

--- a/Logibooks.Core/RestModels/TransportationTypeDto.cs
+++ b/Logibooks.Core/RestModels/TransportationTypeDto.cs
@@ -1,0 +1,28 @@
+namespace Logibooks.Core.RestModels;
+
+using Logibooks.Core.Models;
+
+public class TransportationTypeDto
+{
+    public int Id { get; set; }
+    public TransportationTypeCode Code { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public TransportationTypeDto() {}
+    public TransportationTypeDto(TransportationType type)
+    {
+        Id = type.Id;
+        Code = type.Code;
+        Name = type.Name;
+    }
+
+    public TransportationType ToModel()
+    {
+        return new TransportationType
+        {
+            Id = Id,
+            Code = Code,
+            Name = Name
+        };
+    }
+}

--- a/Logibooks.Core/RestModels/TransportationTypeDto.cs
+++ b/Logibooks.Core/RestModels/TransportationTypeDto.cs
@@ -33,7 +33,6 @@ public class TransportationTypeDto
     public TransportationTypeCode Code { get; set; }
     public string Name { get; set; } = string.Empty;
 
-    public TransportationTypeDto() {}
     public TransportationTypeDto(TransportationType type)
     {
         Id = type.Id;

--- a/Logibooks.Core/RestModels/TransportationTypeDto.cs
+++ b/Logibooks.Core/RestModels/TransportationTypeDto.cs
@@ -1,3 +1,28 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 namespace Logibooks.Core.RestModels;
 
 using Logibooks.Core.Models;
@@ -16,13 +41,4 @@ public class TransportationTypeDto
         Name = type.Name;
     }
 
-    public TransportationType ToModel()
-    {
-        return new TransportationType
-        {
-            Id = Id,
-            Code = Code,
-            Name = Name
-        };
-    }
 }


### PR DESCRIPTION
## Summary
- add `TransportationType` model and enumeration
- seed transportation types in `AppDbContext`
- implement `TransportationTypesController`
- create REST model `TransportationTypeDto`
- add unit tests for new controller

## Testing
- `dotnet build Logibooks.sln -c Release`
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile="**/Migrations/*.cs"`

------
https://chatgpt.com/codex/tasks/task_e_6880a11aea6c8321a905f245dffbd2e0