### PR TITLE
Refactor user checks into service

### DIFF
--- a/Logibooks.Core.Tests/Controllers/CompaniesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/CompaniesControllerTests.cs
@@ -38,6 +38,7 @@ using Logibooks.Core.Controllers;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
 
 namespace Logibooks.Core.Tests.Controllers;
 
@@ -48,6 +49,7 @@ public class CompaniesControllerTests
     private AppDbContext _dbContext;
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<ILogger<CompaniesController>> _mockLogger;
+    private IUserInformationService _userService;
     private CompaniesController _controller;
     private Role _adminRole;
     private Role _userRole;
@@ -90,7 +92,8 @@ public class CompaniesControllerTests
 
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockLogger = new Mock<ILogger<CompaniesController>>();
-        _controller = new CompaniesController(_mockHttpContextAccessor.Object, _dbContext, _mockLogger.Object);
+        _userService = new UserInformationService(_dbContext);
+        _controller = new CompaniesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockLogger.Object);
     }
 
     [TearDown]
@@ -105,7 +108,7 @@ public class CompaniesControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new CompaniesController(_mockHttpContextAccessor.Object, _dbContext, _mockLogger.Object);
+        _controller = new CompaniesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockLogger.Object);
     }
 
     [Test]

--- a/Logibooks.Core.Tests/Controllers/CountriesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/CountriesControllerTests.cs
@@ -25,6 +25,7 @@ public class CountriesControllerTests
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<ILogger<CountriesController>> _mockLogger;
     private Mock<IUpdateCountriesService> _mockService;
+    private IUserInformationService _userService;
     private CountriesController _controller;
     private Role _adminRole;
     private Role _userRole;
@@ -65,7 +66,8 @@ public class CountriesControllerTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockLogger = new Mock<ILogger<CountriesController>>();
         _mockService = new Mock<IUpdateCountriesService>();
-        _controller = new CountriesController(_mockHttpContextAccessor.Object, _dbContext, _mockService.Object, _mockLogger.Object);
+        _userService = new UserInformationService(_dbContext);
+        _controller = new CountriesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockService.Object, _mockLogger.Object);
     }
 
     [TearDown]
@@ -80,7 +82,7 @@ public class CountriesControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new CountriesController(_mockHttpContextAccessor.Object, _dbContext, _mockService.Object, _mockLogger.Object);
+        _controller = new CountriesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockService.Object, _mockLogger.Object);
     }
 
     [Test]

--- a/Logibooks.Core.Tests/Controllers/FeacnCodesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/FeacnCodesControllerTests.cs
@@ -48,6 +48,7 @@ public class FeacnCodesControllerTests
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<IUpdateFeacnCodesService> _mockService;
     private ILogger<FeacnCodesController> _logger;
+    private IUserInformationService _userService;
     private FeacnCodesController _controller;
     private Role _adminRole;
     private Role _userRole;
@@ -88,7 +89,8 @@ public class FeacnCodesControllerTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockService = new Mock<IUpdateFeacnCodesService>();
         _logger = new LoggerFactory().CreateLogger<FeacnCodesController>();
-        _controller = new FeacnCodesController(_mockHttpContextAccessor.Object, _dbContext, _mockService.Object, _logger);
+        _userService = new UserInformationService(_dbContext);
+        _controller = new FeacnCodesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockService.Object, _logger);
     }
 
     [TearDown]
@@ -113,7 +115,7 @@ public class FeacnCodesControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new FeacnCodesController(_mockHttpContextAccessor.Object, _dbContext, _mockService.Object, _logger);
+        _controller = new FeacnCodesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockService.Object, _logger);
     }
 
     [Test]

--- a/Logibooks.Core.Tests/Controllers/OrderStatusesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrderStatusesControllerTests.cs
@@ -2,6 +2,7 @@ using Logibooks.Core.Controllers;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -22,6 +23,7 @@ public class OrderStatusesControllerTests
     private AppDbContext _dbContext;
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private ILogger<OrderStatusesController> _logger;
+    private IUserInformationService _userService;
     private OrderStatusesController _controller;
     private Role _adminRole;
     private Role _logistRole;
@@ -61,7 +63,8 @@ public class OrderStatusesControllerTests
 
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _logger = new LoggerFactory().CreateLogger<OrderStatusesController>();
-        _controller = new OrderStatusesController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+        _userService = new UserInformationService(_dbContext);
+        _controller = new OrderStatusesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger);
     }
 
     [TearDown]
@@ -76,7 +79,7 @@ public class OrderStatusesControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new OrderStatusesController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+        _controller = new OrderStatusesController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger);
     }
 
     [Test]

--- a/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/OrdersControllerTests.cs
@@ -56,6 +56,7 @@ public class OrdersControllerTests
     private IMorphologySearchService _morphologyService;
     private Mock<IRegisterProcessingService> _mockProcessingService;
     private ILogger<OrdersController> _logger;
+    private IUserInformationService _userService;
     private OrdersController _controller;
     private Role _logistRole;
     private User _logistUser;
@@ -95,6 +96,7 @@ public class OrdersControllerTests
         _mockProcessingService = new Mock<IRegisterProcessingService>();
         // Note: Cannot mock static methods GetWBRId() and GetOzonId() - they return constants
         _morphologyService = new MorphologySearchService();
+        _userService = new UserInformationService(_dbContext);
         _controller = CreateController();
     }
 
@@ -111,6 +113,7 @@ public class OrdersControllerTests
         return new OrdersController(
             _mockHttpContextAccessor.Object,
             _dbContext,
+            _userService,
             _logger,
             mockMapper.Object,
             _mockValidationService.Object,
@@ -175,6 +178,7 @@ public class OrdersControllerTests
         _controller = new OrdersController(
             _mockHttpContextAccessor.Object,
             _dbContext,
+            _userService,
             _logger,
             mockMapper.Object,
             _mockValidationService.Object,
@@ -283,6 +287,7 @@ public class OrdersControllerTests
         _controller = new OrdersController(
             _mockHttpContextAccessor.Object,
             _dbContext,
+            _userService,
             _logger,
             mockMapper.Object,
             _mockValidationService.Object,
@@ -320,6 +325,7 @@ public class OrdersControllerTests
         _controller = new OrdersController(
             _mockHttpContextAccessor.Object,
             _dbContext,
+            _userService,
             _logger,
             mockMapper.Object,
             _mockValidationService.Object,
@@ -786,6 +792,7 @@ public class OrdersControllerTests
         var ctrl = new OrdersController(
             _mockHttpContextAccessor.Object,
             _dbContext,
+            _userService,
             _logger,
             new Mock<IMapper>().Object,
             validationSvc,

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -52,6 +52,7 @@ public class RegistersControllerTests
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<IRegisterValidationService> _mockRegValidationService;
     private ILogger<RegistersController> _logger;
+    private IUserInformationService _userService;
     private Role _logistRole;
     private Role _adminRole;
     private User _logistUser;
@@ -102,7 +103,8 @@ public class RegistersControllerTests
         _mockRegValidationService = new Mock<IRegisterValidationService>();
         _mockProcessingService = new Mock<IRegisterProcessingService>();
         _logger = new LoggerFactory().CreateLogger<RegistersController>();
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _userService = new UserInformationService(_dbContext);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
     }
 
     [TearDown]
@@ -117,7 +119,7 @@ public class RegistersControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
     }
 
     [Test]
@@ -1563,7 +1565,7 @@ public class RegistersControllerTests
 
         // Update the logger type to match the expected type for RegisterValidationService
         var realRegSvc = new RegisterValidationService(_dbContext, scopeFactoryMock.Object, new LoggerFactory().CreateLogger<RegisterValidationService>(), new MorphologySearchService(), new FeacnPrefixCheckService(_dbContext));
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _logger, realRegSvc, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, realRegSvc, _mockProcessingService.Object);
 
         var result = await _controller.ValidateRegister(200);
         var handle = ((GuidReference)((OkObjectResult)result.Result!).Value!).Id;

--- a/Logibooks.Core.Tests/Controllers/StopWordsControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StopWordsControllerTests.cs
@@ -51,6 +51,7 @@ public class StopWordsControllerTests
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<IMorphologySearchService> _mockMorphologySearchService;
     private ILogger<StopWordsController> _logger;
+    private IUserInformationService _userService;
     private StopWordsController _controller;
     private Role _adminRole;
     private Role _logistRole;
@@ -94,9 +95,10 @@ public class StopWordsControllerTests
         // Setup default behavior: return true for all words unless specifically overridden
         _mockMorphologySearchService.Setup(x => x.CheckWord(It.IsAny<string>()))
             .Returns(true);
-        
+
         _logger = new LoggerFactory().CreateLogger<StopWordsController>();
-        _controller = new StopWordsController(_mockHttpContextAccessor.Object, _dbContext, _logger, _mockMorphologySearchService.Object);
+        _userService = new UserInformationService(_dbContext);
+        _controller = new StopWordsController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockMorphologySearchService.Object);
     }
 
     private static bool IsEnglishWord(string word)
@@ -117,7 +119,7 @@ public class StopWordsControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new StopWordsController(_mockHttpContextAccessor.Object, _dbContext, _logger, _mockMorphologySearchService.Object);
+        _controller = new StopWordsController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockMorphologySearchService.Object);
     }
 
     [Test]

--- a/Logibooks.Core.Tests/Controllers/UserControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/UserControllerTests.cs
@@ -39,6 +39,7 @@ using Logibooks.Core.Controllers;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
 
 namespace Logibooks.Core.Tests.Controllers;
 
@@ -49,6 +50,7 @@ public class UsersControllerTests
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<ILogger<UsersController>> _mockLogger;
     private AppDbContext _dbContext;
+    private IUserInformationService _userService;
     private UsersController _controller;
     private User _adminUser;
     private User _regularUser;
@@ -105,6 +107,8 @@ public class UsersControllerTests
         // Setup mocks
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockLogger = new Mock<ILogger<UsersController>>();
+
+        _userService = new UserInformationService(_dbContext);
 
         // Save entities to database
         _dbContext.SaveChanges();
@@ -576,6 +580,6 @@ public class UsersControllerTests
         var httpContext = new DefaultHttpContext();
         httpContext.Items["UserId"] = userId;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
-        _controller = new UsersController(_mockHttpContextAccessor.Object, _dbContext, _mockLogger.Object);
+        _controller = new UsersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _mockLogger.Object);
     }
 }

--- a/Logibooks.Core.Tests/Data/AppDbContextTests.cs
+++ b/Logibooks.Core.Tests/Data/AppDbContextTests.cs
@@ -27,13 +27,14 @@ using NUnit.Framework;
 using Microsoft.EntityFrameworkCore;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
+using Logibooks.Core.Services;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Collections.Generic;
 
 namespace Logibooks.Core.Tests.Data;
 
-public class AppDbContextTests
+public class UserInformationServiceTests
 {
     private static readonly int LogistRoleId = 1;
     private static readonly int AdminRoleId = 2;
@@ -91,21 +92,24 @@ public class AppDbContextTests
     public void CheckSameUser_ReturnsTrue_WhenIdsMatch()
     {
         using var ctx = CreateContext();
-        Assert.That(ctx.CheckSameUser(1, 1), Is.True);
+        var svc = new UserInformationService(ctx);
+        Assert.That(svc.CheckSameUser(1, 1), Is.True);
     }
 
     [Test]
     public void CheckSameUser_ReturnsFalse_WhenIdsDiffer()
     {
         using var ctx = CreateContext();
-        Assert.That(ctx.CheckSameUser(1, 2), Is.False);
+        var svc = new UserInformationService(ctx);
+        Assert.That(svc.CheckSameUser(1, 2), Is.False);
     }
 
     [Test]
     public void CheckSameUser_ReturnsFalse_WhenCuidZero()
     {
         using var ctx = CreateContext();
-        Assert.That(ctx.CheckSameUser(1, 0), Is.False);
+        var svc = new UserInformationService(ctx);
+        Assert.That(svc.CheckSameUser(1, 0), Is.False);
     }
 
     #endregion
@@ -117,12 +121,13 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(10, "admin@test.com", "password", "Admin", "User", null, [GetAdminRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.CheckAdmin(10);
+        var result = await svc.CheckAdmin(10);
 
         // Assert
         Assert.That(result, Is.True);
@@ -133,13 +138,14 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         var user = CreateUser(11, "logist@test.com", "password", "Logist", "User", null, [GetLogistRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.CheckAdmin(11);
+        var result = await svc.CheckAdmin(11);
 
         // Assert
         Assert.That(result, Is.False);
@@ -150,9 +156,10 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         // Act
-        var result = await ctx.CheckAdmin(999);
+        var result = await svc.CheckAdmin(999);
 
         // Assert
         Assert.That(result, Is.False);
@@ -163,12 +170,13 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(12, "norole@test.com", "password", "No", "Role", null, []);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.CheckAdmin(12);
+        var result = await svc.CheckAdmin(12);
 
         // Assert
         Assert.That(result, Is.False);
@@ -182,11 +190,12 @@ public class AppDbContextTests
     public async Task CheckLogist_ReturnsTrue_WhenUserIsLogist()
     {
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(30, "logist@test.com", "password", "Log", "User", null, [GetLogistRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
-        var result = await ctx.CheckLogist(30);
+        var result = await svc.CheckLogist(30);
 
         Assert.That(result, Is.True);
     }
@@ -195,11 +204,12 @@ public class AppDbContextTests
     public async Task CheckLogist_ReturnsFalse_WhenUserIsNotLogist()
     {
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(31, "adminonly@test.com", "password", "Adm", "User", null, [GetAdminRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
-        var result = await ctx.CheckLogist(31);
+        var result = await svc.CheckLogist(31);
 
         Assert.That(result, Is.False);
     }
@@ -208,8 +218,9 @@ public class AppDbContextTests
     public async Task CheckLogist_ReturnsFalse_WhenUserDoesNotExist()
     {
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
-        var result = await ctx.CheckLogist(999);
+        var result = await svc.CheckLogist(999);
 
         Assert.That(result, Is.False);
     }
@@ -218,11 +229,12 @@ public class AppDbContextTests
     public async Task CheckLogist_ReturnsFalse_WhenUserHasNoRoles()
     {
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(32, "norolelogist@test.com", "password", "No", "Role", null, []);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
-        var result = await ctx.CheckLogist(32);
+        var result = await svc.CheckLogist(32);
 
         Assert.That(result, Is.False);
     }
@@ -236,9 +248,10 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         // Act
-        var result = await ctx.CheckAdminOrSameUser(5, 5);
+        var result = await svc.CheckAdminOrSameUser(5, 5);
 
         // Assert
         Assert.That(result.Value, Is.True);
@@ -249,9 +262,10 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         // Act
-        var result = await ctx.CheckAdminOrSameUser(5, 0);
+        var result = await svc.CheckAdminOrSameUser(5, 0);
 
         // Assert
         Assert.That(result.Value, Is.False);
@@ -262,12 +276,13 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(20, "admin2@test.com", "password", "Admin", "Two", null, [GetAdminRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.CheckAdminOrSameUser(5, 20);
+        var result = await svc.CheckAdminOrSameUser(5, 20);
 
         // Assert
         Assert.That(result.Value, Is.True);
@@ -278,12 +293,13 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(21, "logist2@test.com", "password", "Logist", "Two", null, [GetLogistRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.CheckAdminOrSameUser(5, 21);
+        var result = await svc.CheckAdminOrSameUser(5, 21);
 
         // Assert
         Assert.That(result.Value, Is.False);
@@ -298,10 +314,11 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         ctx.Users.Add(CreateUser(30, "exists@test.com", "password", "Exists", "User", null, []));
         ctx.SaveChanges();
         // Act
-        var result = ctx.Exists(30);
+        var result = svc.Exists(30);
 
         // Assert
         Assert.That(result, Is.True);
@@ -312,9 +329,10 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         // Act
-        var result = ctx.Exists(999);
+        var result = svc.Exists(999);
 
         // Assert
         Assert.That(result, Is.False);
@@ -325,10 +343,11 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         ctx.Users.Add(CreateUser(31, "email_exists@test.com", "password", "Email", "Exists", null, []));
         ctx.SaveChanges();
         // Act
-        var result = ctx.Exists("email_exists@test.com");
+        var result = svc.Exists("email_exists@test.com");
 
         // Assert
         Assert.That(result, Is.True);
@@ -339,9 +358,10 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         // Act
-        var result = ctx.Exists("nonexistent@test.com");
+        var result = svc.Exists("nonexistent@test.com");
 
         // Assert
         Assert.That(result, Is.False);
@@ -352,10 +372,11 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         ctx.Users.Add(CreateUser(32, "case_test@test.com", "password", "Case", "Test", null, []));
         ctx.SaveChanges();
         // Act
-        var result = ctx.Exists("CASE_TEST@test.com");
+        var result = svc.Exists("CASE_TEST@test.com");
 
         // Assert
         Assert.That(result, Is.True);
@@ -370,12 +391,13 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(40, "viewitem@test.com", "password", "View", "Item", "Test", [GetLogistRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.UserViewItem(40);
+        var result = await svc.UserViewItem(40);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -393,9 +415,10 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
 
         // Act
-        var result = await ctx.UserViewItem(999);
+        var result = await svc.UserViewItem(999);
 
         // Assert
         Assert.That(result, Is.Null);
@@ -406,12 +429,13 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         var user = CreateUser(41, "multirole@test.com", "password", "Multi", "Role", "", [GetLogistRole(ctx), GetAdminRole(ctx)]);
         ctx.Users.Add(user);
         await ctx.SaveChangesAsync();
 
         // Act
-        var result = await ctx.UserViewItem(41);
+        var result = await svc.UserViewItem(41);
 
         // Assert
         Assert.That(result, Is.Not.Null);
@@ -429,13 +453,14 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         ctx.Users.Add(CreateUser(50, "user1@test.com", "password", "User", "One", null, [GetLogistRole(ctx)]));
         ctx.Users.Add(CreateUser(51, "user2@test.com", "password", "User", "Two", null, [GetAdminRole(ctx)]));
 
         await ctx.SaveChangesAsync();
 
         // Act
-        var results = await ctx.UserViewItems();
+        var results = await svc.UserViewItems();
 
         // Assert
         Assert.That(results, Has.Count.GreaterThanOrEqualTo(2));
@@ -454,6 +479,7 @@ public class AppDbContextTests
     {
         // Arrange
         using var ctx = CreateContext();
+        var svc = new UserInformationService(ctx);
         // Clear users table - only do this in a test-specific database
         foreach (var user in ctx.Users.ToList())
         {
@@ -462,7 +488,7 @@ public class AppDbContextTests
         await ctx.SaveChangesAsync();
 
         // Act
-        var results = await ctx.UserViewItems();
+        var results = await svc.UserViewItems();
 
         // Assert
         Assert.That(results, Is.Empty);

--- a/Logibooks.Core.Tests/Data/AppDbContextTests.cs
+++ b/Logibooks.Core.Tests/Data/AppDbContextTests.cs
@@ -254,7 +254,7 @@ public class UserInformationServiceTests
         var result = await svc.CheckAdminOrSameUser(5, 5);
 
         // Assert
-        Assert.That(result.Value, Is.True);
+        Assert.That(result, Is.True);
     }
 
     [Test]
@@ -268,7 +268,7 @@ public class UserInformationServiceTests
         var result = await svc.CheckAdminOrSameUser(5, 0);
 
         // Assert
-        Assert.That(result.Value, Is.False);
+        Assert.That(result, Is.False);
     }
 
     [Test]
@@ -285,7 +285,7 @@ public class UserInformationServiceTests
         var result = await svc.CheckAdminOrSameUser(5, 20);
 
         // Assert
-        Assert.That(result.Value, Is.True);
+        Assert.That(result, Is.True);
     }
 
     [Test]
@@ -302,7 +302,7 @@ public class UserInformationServiceTests
         var result = await svc.CheckAdminOrSameUser(5, 21);
 
         // Assert
-        Assert.That(result.Value, Is.False);
+        Assert.That(result, Is.False);
     }
 
     #endregion

--- a/Logibooks.Core/Controllers/CompaniesController.cs
+++ b/Logibooks.Core/Controllers/CompaniesController.cs
@@ -28,6 +28,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Logibooks.Core.Authorization;
 using Logibooks.Core.Data;
+using Logibooks.Core.Services;
 using Logibooks.Core.RestModels;
 
 namespace Logibooks.Core.Controllers;
@@ -40,8 +41,10 @@ namespace Logibooks.Core.Controllers;
 public class CompaniesController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     ILogger<CompaniesController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
 
     const int _companyOzon = 1; // Ozon company ID
     const int _companyWBR = 2;  // WBR company ID
@@ -69,7 +72,7 @@ public class CompaniesController(
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
     public async Task<ActionResult<CompanyDto>> PostCompany(CompanyDto dto)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         if (await _db.Companies.AnyAsync(c => c.Inn == dto.Inn))
         {
             return _409CompanyInn(dto.Inn);
@@ -97,7 +100,7 @@ public class CompaniesController(
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
     public async Task<IActionResult> PutCompany(int id, CompanyDto dto)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         if (id != dto.Id) return BadRequest();
 
         var company = await _db.Companies.FindAsync(id);
@@ -136,7 +139,7 @@ public class CompaniesController(
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
     public async Task<IActionResult> DeleteCompany(int id)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         var company = await _db.Companies.FindAsync(id);
         if (company == null) return _404Object(id);
 

--- a/Logibooks.Core/Controllers/CountriesController.cs
+++ b/Logibooks.Core/Controllers/CountriesController.cs
@@ -42,9 +42,11 @@ namespace Logibooks.Core.Controllers;
 public class CountriesController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     IUpdateCountriesService service,
     ILogger<CountriesController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
     private readonly IUpdateCountriesService _service = service;
 
     [HttpGet]
@@ -87,7 +89,7 @@ public class CountriesController(
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     public async Task<IActionResult> Update()
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         await _service.RunAsync();
         return NoContent();
     }

--- a/Logibooks.Core/Controllers/FeacnCodesController.cs
+++ b/Logibooks.Core/Controllers/FeacnCodesController.cs
@@ -43,9 +43,11 @@ namespace Logibooks.Core.Controllers;
 public class FeacnCodesController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     IUpdateFeacnCodesService service,
     ILogger<FeacnCodesController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
     private readonly IUpdateFeacnCodesService _service = service;
 
     private async Task<List<TDto>> FetchAndConvertAsync<TEntity, TDto>(
@@ -90,7 +92,7 @@ public class FeacnCodesController(
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     public async Task<IActionResult> Update()
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         await _service.RunAsync();
         return NoContent();
     }

--- a/Logibooks.Core/Controllers/OrderStatusesController.cs
+++ b/Logibooks.Core/Controllers/OrderStatusesController.cs
@@ -5,6 +5,7 @@ using Logibooks.Core.Authorization;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
 
 namespace Logibooks.Core.Controllers;
 
@@ -17,8 +18,10 @@ namespace Logibooks.Core.Controllers;
 public class OrderStatusesController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     ILogger<OrderStatusesController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<OrderStatusDto>))]
     public async Task<ActionResult<IEnumerable<OrderStatusDto>>> GetStatuses()
@@ -42,7 +45,7 @@ public class OrderStatusesController(
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     public async Task<ActionResult<Reference>> CreateStatus(OrderStatusDto dto)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         var status = dto.ToModel();
         _db.Statuses.Add(status);
         await _db.SaveChangesAsync();
@@ -56,7 +59,7 @@ public class OrderStatusesController(
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
     public async Task<IActionResult> UpdateStatus(int id, OrderStatusDto dto)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         if (id != dto.Id) return BadRequest();
         var status = await _db.Statuses.FindAsync(id);
         if (status == null) return _404Object(id);
@@ -73,7 +76,7 @@ public class OrderStatusesController(
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
     public async Task<IActionResult> DeleteStatus(int id)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         var status = await _db.Statuses.FindAsync(id);
         if (status == null) return _404Object(id);
 

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -45,6 +45,7 @@ namespace Logibooks.Core.Controllers;
 public class OrdersController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     ILogger<OrdersController> logger,
     IMapper mapper,
     IOrderValidationService validationService,
@@ -52,6 +53,7 @@ public class OrdersController(
     IRegisterProcessingService processingService) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
     private const int MaxPageSize = 1000;
+    private readonly IUserInformationService _userService = userService;
     private readonly IMapper _mapper = mapper;
     private readonly IOrderValidationService _validationService = validationService;
     private readonly IMorphologySearchService _morphologyService = morphologyService;
@@ -65,7 +67,7 @@ public class OrdersController(
     {
         _logger.LogDebug("GetOrder for id={id}", id);
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("GetOrder returning '403 Forbidden'");
@@ -134,7 +136,7 @@ public class OrdersController(
     {
         _logger.LogDebug("UpdateOrder for id={id}", id);
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("UpdateOrder returning '403 Forbidden'");
@@ -206,7 +208,7 @@ public class OrdersController(
     {
         _logger.LogDebug("DeleteOrder for id={id}", id);
 
-        if (!await _db.CheckLogist(_curUserId))
+        if (!await _userService.CheckLogist(_curUserId))
         {
             _logger.LogDebug("DeleteOrder returning '403 Forbidden'");
             return _403();
@@ -276,7 +278,7 @@ public class OrdersController(
             return _400();
         }
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("GetOrders returning '403 Forbidden'");
@@ -356,7 +358,7 @@ public class OrdersController(
     {
         _logger.LogDebug("ValidateOrder for id={id}", id);
 
-        if (!await _db.CheckLogist(_curUserId))
+        if (!await _userService.CheckLogist(_curUserId))
         {
             _logger.LogDebug("ValidateOrder returning '403 Forbidden'");
             return _403();

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -43,10 +43,12 @@ namespace Logibooks.Core.Controllers;
 public class RegistersController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     ILogger<RegistersController> logger,
     IRegisterValidationService validationService,
     IRegisterProcessingService processingService) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
 
     private readonly string[] allowedSortBy = ["id", "filename", "date", "orderstotal"];
     private readonly int maxPageSize = 100;
@@ -62,7 +64,7 @@ public class RegistersController(
     {
         _logger.LogDebug("GetRegister for id={id}", id);
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("GetRegister returning '403 Forbidden'");
@@ -133,7 +135,7 @@ public class RegistersController(
             return _400();
         }
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("GetRegisters returning '403 Forbidden'");
@@ -225,7 +227,7 @@ public class RegistersController(
 
         int cId = companyId ?? IRegisterProcessingService.GetWBRId();
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("UploadRegister returning '403 Forbidden'");
@@ -333,7 +335,7 @@ public class RegistersController(
     {
         _logger.LogDebug("DeleteRegister for id={id}", id);
 
-        var ok = await _db.CheckLogist(_curUserId);
+        var ok = await _userService.CheckLogist(_curUserId);
         if (!ok)
         {
             _logger.LogDebug("DeleteRegister returning '403 Forbidden'");
@@ -370,7 +372,7 @@ public class RegistersController(
     {
         _logger.LogDebug("SetOrderStatuses for registerId={id} statusId={statusId}", id, statusId);
 
-        if (!await _db.CheckLogist(_curUserId))
+        if (!await _userService.CheckLogist(_curUserId))
         {
             _logger.LogDebug("SetOrderStatuses returning '403 Forbidden'");
             return _403();
@@ -404,7 +406,7 @@ public class RegistersController(
     {
         _logger.LogDebug("ValidateRegister for id={id}", id);
 
-        if (!await _db.CheckLogist(_curUserId))
+        if (!await _userService.CheckLogist(_curUserId))
         {
             _logger.LogDebug("ValidateRegister returning '403 Forbidden'");
             return _403();
@@ -428,7 +430,7 @@ public class RegistersController(
     {
         _logger.LogDebug("GetValidationProgress for handle={handle}", handleId);
 
-        if (!await _db.CheckLogist(_curUserId))
+        if (!await _userService.CheckLogist(_curUserId))
         {
             _logger.LogDebug("GetValidationProgress returning '403 Forbidden'");
             return _403();
@@ -452,7 +454,7 @@ public class RegistersController(
     {
         _logger.LogDebug("CancelValidation for handle={handle}", handleId);
 
-        if (!await _db.CheckLogist(_curUserId))
+        if (!await _userService.CheckLogist(_curUserId))
         {
             _logger.LogDebug("CancelValidation returning '403 Forbidden'");
             return _403();

--- a/Logibooks.Core/Controllers/StopWordsController.cs
+++ b/Logibooks.Core/Controllers/StopWordsController.cs
@@ -42,9 +42,11 @@ namespace Logibooks.Core.Controllers;
 public class StopWordsController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     ILogger<StopWordsController> logger,
     IMorphologySearchService morphologySearchService) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
     private readonly IMorphologySearchService _morphologySearchService = morphologySearchService;
 
     [HttpGet]
@@ -71,7 +73,7 @@ public class StopWordsController(
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ErrMessage))]
     public async Task<ActionResult<StopWordDto>> PostStopWord(StopWordDto dto)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         
         if (!dto.ExactMatch)
         {
@@ -110,7 +112,7 @@ public class StopWordsController(
     [ProducesResponseType(StatusCodes.Status501NotImplemented, Type = typeof(ErrMessage))]
     public async Task<IActionResult> PutStopWord(int id, StopWordDto dto)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         if (id != dto.Id) return BadRequest();
         var sw = await _db.StopWords.FindAsync(id);
         if (sw == null) return _404Object(id);
@@ -152,7 +154,7 @@ public class StopWordsController(
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
     public async Task<IActionResult> DeleteStopWord(int id)
     {
-        if (!await _db.CheckAdmin(_curUserId)) return _403();
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
         var sw = await _db.StopWords.FindAsync(id);
         if (sw == null) return _404Object(id);
 

--- a/Logibooks.Core/Controllers/UsersController.cs
+++ b/Logibooks.Core/Controllers/UsersController.cs
@@ -82,7 +82,7 @@ public class UsersController(
     {
         _logger.LogDebug("GetUser for id={id}", id);
         var ch = await _userService.CheckAdminOrSameUser(id, _curUserId);
-        if (ch == null || !ch.Value)
+        if (!ch)
         {
             _logger.LogDebug("GetUser returning '403 Forbidden'");
             return _403();

--- a/Logibooks.Core/Controllers/UsersController.cs
+++ b/Logibooks.Core/Controllers/UsersController.cs
@@ -32,6 +32,7 @@ using Logibooks.Core.Authorization;
 using Logibooks.Core.RestModels;
 using Logibooks.Core.Settings;
 using Logibooks.Core.Data;
+using Logibooks.Core.Services;
 using Logibooks.Core.Models;
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
@@ -47,8 +48,10 @@ namespace Logibooks.Core.Controllers;
 public class UsersController(
     IHttpContextAccessor httpContextAccessor,
     AppDbContext db,
+    IUserInformationService userService,
     ILogger<UsersController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
 {
+    private readonly IUserInformationService _userService = userService;
     // GET: api/users
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<UserViewItem>))]
@@ -56,7 +59,7 @@ public class UsersController(
     public async Task<ActionResult<IEnumerable<UserViewItem>>> GetUsers()
     {
         _logger.LogDebug("GetUsers");
-        var ch = await _db.CheckAdmin(_curUserId);
+        var ch = await _userService.CheckAdmin(_curUserId);
         if (!ch)
         {
             if (!ch)
@@ -64,7 +67,7 @@ public class UsersController(
             return _403();
         }
 
-        var res = await _db.UserViewItems();
+        var res = await _userService.UserViewItems();
         _logger.LogDebug("GetUsers returning:\n{items}\n", JsonSerializer.Serialize(res, JOptions.DefaultOptions));
 
         return res;
@@ -78,14 +81,14 @@ public class UsersController(
     public async Task<ActionResult<UserViewItem>> GetUser(int id)
     {
         _logger.LogDebug("GetUser for id={id}", id);
-        var ch = await _db.CheckAdminOrSameUser(id, _curUserId);
+        var ch = await _userService.CheckAdminOrSameUser(id, _curUserId);
         if (ch == null || !ch.Value)
         {
             _logger.LogDebug("GetUser returning '403 Forbidden'");
             return _403();
         }
 
-        var user = await _db.UserViewItem(id);
+        var user = await _userService.UserViewItem(id);
         if (user == null)
         {
             _logger.LogDebug("GetUser returning '404 Not Found'");
@@ -104,14 +107,14 @@ public class UsersController(
     public async Task<ActionResult<Reference>> PostUser(UserCreateItem user)
     {
         _logger.LogDebug("PostUser (create) for {user}", user.ToString());
-        var ch = await _db.CheckAdmin(_curUserId);
+        var ch = await _userService.CheckAdmin(_curUserId);
         if (!ch)
         {
             _logger.LogDebug("PostUser returning '403 Forbidden'");
             return _403();
         }
 
-        if (_db.Exists(user.Email))
+        if (_userService.Exists(user.Email))
         {
             _logger.LogDebug("PostUser returning '409 Conflict'");
             return _409Email(user.Email);
@@ -174,8 +177,8 @@ public class UsersController(
         bool adminRequired = update.IsAdministrator() && !user.IsAdministrator();
 
         ActionResult<bool> ch;
-        ch = adminRequired ? await _db.CheckAdmin(_curUserId) :
-                             await _db.CheckAdminOrSameUser(id, _curUserId);
+        ch = adminRequired ? await _userService.CheckAdmin(_curUserId) :
+                             await _userService.CheckAdminOrSameUser(id, _curUserId);
         if (ch == null || !ch.Value)
         {
             _logger.LogDebug("PutUser returning '403 Forbidden'");
@@ -184,7 +187,7 @@ public class UsersController(
 
         if (update.Email != null && user.Email != update.Email)
         {
-            if (_db.Exists(update.Email)) return _409Email(update.Email);
+            if (_userService.Exists(update.Email)) return _409Email(update.Email);
             user.Email = update.Email;
         }
 
@@ -233,7 +236,7 @@ public class UsersController(
     public async Task<IActionResult> DeleteUser(int id)
     {
         _logger.LogDebug("DeleteUser for id={id}", id);
-        var ch = await _db.CheckAdmin(_curUserId);
+        var ch = await _userService.CheckAdmin(_curUserId);
         if (!ch)
         {
             _logger.LogDebug("DeleteUser returning '403 Forbidden'");

--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -24,8 +24,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 using Logibooks.Core.Models;
-using Logibooks.Core.RestModels;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 namespace Logibooks.Core.Data
 {
@@ -51,66 +49,6 @@ namespace Logibooks.Core.Data
         public DbSet<CustomsProcedure> CustomsProcedures => Set<CustomsProcedure>();
         public DbSet<BaseOrderFeacnPrefix> BaseOrderFeacnPrefixes => Set<BaseOrderFeacnPrefix>();
         public DbSet<TransportationType> TransportationTypes => Set<TransportationType>();
-        public async Task<bool> CheckAdmin(int cuid)
-        {
-            var user = await Users
-                .AsNoTracking()
-                .Include(u => u.UserRoles)
-                    .ThenInclude(ur => ur.Role)
-                .Where(x => x.Id == cuid)
-                .FirstOrDefaultAsync(); 
-            return user != null && user.IsAdministrator();
-        }
-        public async Task<bool> CheckLogist(int cuid)
-        {
-            var user = await Users
-                .AsNoTracking()
-                .Include(u => u.UserRoles)
-                    .ThenInclude(ur => ur.Role)
-                .Where(x => x.Id == cuid)
-                .FirstOrDefaultAsync();
-            return user != null && user.IsLogist();
-        }
-        public async Task<ActionResult<bool>> CheckAdminOrSameUser(int id, int cuid)
-        {
-            if (cuid == 0) return false;
-            if (cuid == id) return true;
-            return await CheckAdmin(cuid);
-        }
-        public bool CheckSameUser(int id, int cuid)
-        {
-            if (cuid == 0) return false;
-            if (cuid == id) return true;
-            return false;
-        }
-        public bool Exists(int id)
-        {
-            return Users.Any(e => e.Id == id);
-        }
-        public bool Exists(string email)
-        {
-            return Users.Any(u => u.Email.ToLower() == email.ToLower());
-        }
-        public async Task<UserViewItem?> UserViewItem(int id)
-        {
-            var user = await Users
-                .AsNoTracking()
-                .Include(u => u.UserRoles)
-                    .ThenInclude(ur => ur.Role)
-                .Where(x => x.Id == id)
-                .Select(x => new UserViewItem(x))
-                .FirstOrDefaultAsync();
-            return user ?? null;
-        }
-        public async Task<List<UserViewItem>> UserViewItems()
-        {
-            return await Users
-                .AsNoTracking()
-                .Include(u => u.UserRoles)
-                    .ThenInclude(ur => ur.Role)
-                .Select(x => new UserViewItem(x))
-                .ToListAsync();
-        }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -59,6 +59,7 @@ builder.Services
     .AddScoped<IOrderValidationService, OrderValidationService>()
     .AddScoped<IRegisterValidationService, RegisterValidationService>()
     .AddScoped<IRegisterProcessingService, RegisterProcessingService>()
+    .AddScoped<IUserInformationService, UserInformationService>()
     .AddSingleton<IMorphologySearchService, MorphologySearchService>()
     .AddScoped<UnhandledExceptionFilter>()
     .AddHttpContextAccessor()

--- a/Logibooks.Core/Services/IUserInformationService.cs
+++ b/Logibooks.Core/Services/IUserInformationService.cs
@@ -1,0 +1,16 @@
+namespace Logibooks.Core.Services;
+
+using Microsoft.AspNetCore.Mvc;
+using Logibooks.Core.RestModels;
+
+public interface IUserInformationService
+{
+    Task<bool> CheckAdmin(int cuid);
+    Task<bool> CheckLogist(int cuid);
+    Task<ActionResult<bool>> CheckAdminOrSameUser(int id, int cuid);
+    bool CheckSameUser(int id, int cuid);
+    bool Exists(int id);
+    bool Exists(string email);
+    Task<UserViewItem?> UserViewItem(int id);
+    Task<List<UserViewItem>> UserViewItems();
+}

--- a/Logibooks.Core/Services/IUserInformationService.cs
+++ b/Logibooks.Core/Services/IUserInformationService.cs
@@ -7,7 +7,7 @@ public interface IUserInformationService
 {
     Task<bool> CheckAdmin(int cuid);
     Task<bool> CheckLogist(int cuid);
-    Task<ActionResult<bool>> CheckAdminOrSameUser(int id, int cuid);
+    Task<bool> CheckAdminOrSameUser(int id, int cuid);
     bool CheckSameUser(int id, int cuid);
     bool Exists(int id);
     bool Exists(string email);

--- a/Logibooks.Core/Services/UserInformationService.cs
+++ b/Logibooks.Core/Services/UserInformationService.cs
@@ -64,7 +64,7 @@ public class UserInformationService(AppDbContext db) : IUserInformationService
             .Where(x => x.Id == id)
             .Select(x => new UserViewItem(x))
             .FirstOrDefaultAsync();
-        return user ?? null;
+        return user;
     }
 
     public async Task<List<UserViewItem>> UserViewItems()

--- a/Logibooks.Core/Services/UserInformationService.cs
+++ b/Logibooks.Core/Services/UserInformationService.cs
@@ -52,7 +52,7 @@ public class UserInformationService(AppDbContext db) : IUserInformationService
 
     public bool Exists(string email)
     {
-        return _db.Users.Any(u => u.Email.ToLower() == email.ToLower());
+        return _db.Users.Any(u => string.Equals(u.Email, email, StringComparison.OrdinalIgnoreCase));
     }
 
     public async Task<UserViewItem?> UserViewItem(int id)

--- a/Logibooks.Core/Services/UserInformationService.cs
+++ b/Logibooks.Core/Services/UserInformationService.cs
@@ -31,7 +31,7 @@ public class UserInformationService(AppDbContext db) : IUserInformationService
         return user != null && user.IsLogist();
     }
 
-    public async Task<ActionResult<bool>> CheckAdminOrSameUser(int id, int cuid)
+    public async Task<bool> CheckAdminOrSameUser(int id, int cuid)
     {
         if (cuid == 0) return false;
         if (cuid == id) return true;

--- a/Logibooks.Core/Services/UserInformationService.cs
+++ b/Logibooks.Core/Services/UserInformationService.cs
@@ -1,0 +1,79 @@
+namespace Logibooks.Core.Services;
+
+using Logibooks.Core.Data;
+using Logibooks.Core.RestModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+public class UserInformationService(AppDbContext db) : IUserInformationService
+{
+    private readonly AppDbContext _db = db;
+
+    public async Task<bool> CheckAdmin(int cuid)
+    {
+        var user = await _db.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .Where(x => x.Id == cuid)
+            .FirstOrDefaultAsync();
+        return user != null && user.IsAdministrator();
+    }
+
+    public async Task<bool> CheckLogist(int cuid)
+    {
+        var user = await _db.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .Where(x => x.Id == cuid)
+            .FirstOrDefaultAsync();
+        return user != null && user.IsLogist();
+    }
+
+    public async Task<ActionResult<bool>> CheckAdminOrSameUser(int id, int cuid)
+    {
+        if (cuid == 0) return false;
+        if (cuid == id) return true;
+        return await CheckAdmin(cuid);
+    }
+
+    public bool CheckSameUser(int id, int cuid)
+    {
+        if (cuid == 0) return false;
+        if (cuid == id) return true;
+        return false;
+    }
+
+    public bool Exists(int id)
+    {
+        return _db.Users.Any(e => e.Id == id);
+    }
+
+    public bool Exists(string email)
+    {
+        return _db.Users.Any(u => u.Email.ToLower() == email.ToLower());
+    }
+
+    public async Task<UserViewItem?> UserViewItem(int id)
+    {
+        var user = await _db.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .Where(x => x.Id == id)
+            .Select(x => new UserViewItem(x))
+            .FirstOrDefaultAsync();
+        return user ?? null;
+    }
+
+    public async Task<List<UserViewItem>> UserViewItems()
+    {
+        return await _db.Users
+            .AsNoTracking()
+            .Include(u => u.UserRoles)
+                .ThenInclude(ur => ur.Role)
+            .Select(x => new UserViewItem(x))
+            .ToListAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- move user helper methods from `AppDbContext` into new `UserInformationService`
- register the service for dependency injection
- update controllers to use `IUserInformationService`
- adjust unit tests for new constructor parameters

## Testing
- `dotnet test ./Logibooks.Core.Tests/Logibooks.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68814d9256f88321a6fd45ce3c10c045