### PR TITLE
Add IndPost XML generator service

### DIFF
--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -59,6 +59,7 @@ builder.Services
     .AddScoped<IOrderValidationService, OrderValidationService>()
     .AddScoped<IRegisterValidationService, RegisterValidationService>()
     .AddScoped<IRegisterProcessingService, RegisterProcessingService>()
+    .AddScoped<IIndPostXmlService, IndPostXmlService>()
     .AddScoped<IUserInformationService, UserInformationService>()
     .AddSingleton<IMorphologySearchService, MorphologySearchService>()
     .AddScoped<UnhandledExceptionFilter>()

--- a/Logibooks.Core/Services/IIndPostXmlService.cs
+++ b/Logibooks.Core/Services/IIndPostXmlService.cs
@@ -1,0 +1,15 @@
+using System.Xml;
+
+namespace Logibooks.Core.Services;
+
+public interface IIndPostXmlService
+{
+    /// <summary>
+    /// Generates an AltaIndPost XML document using values provided in the dictionary.
+    /// Keys correspond to element names under the root element.
+    /// Unknown keys are ignored.
+    /// </summary>
+    /// <param name="values">Mapping from element name to value.</param>
+    /// <returns>Created XML document.</returns>
+    XmlDocument Generate(Dictionary<string, string?> values);
+}

--- a/Logibooks.Core/Services/IndPostXmlService.cs
+++ b/Logibooks.Core/Services/IndPostXmlService.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Xml;
+using System.Xml.Schema;
+
+namespace Logibooks.Core.Services;
+
+/// <summary>
+/// Service for creating AltaIndPost XML documents based on the IndPost.xsd schema.
+/// Only top level elements are supported. Extra elements in the input are skipped.
+/// </summary>
+public class IndPostXmlService : IIndPostXmlService
+{
+    private readonly XmlSchemaSet _schemas = new();
+    private readonly string[] _allowedElements;
+
+    public IndPostXmlService()
+    {
+        var schemaPath = Path.Combine(AppContext.BaseDirectory, "mapping", "IndPost.xsd");
+        using var fs = File.OpenRead(schemaPath);
+        var schema = XmlSchema.Read(fs, null) ?? throw new InvalidOperationException("Failed to load XSD");
+        _schemas.Add(schema);
+
+        // collect allowed direct child element names of AltaIndPost
+        _allowedElements = schema.Items
+            .OfType<XmlSchemaElement>()
+            .Where(e => e.Name == "AltaIndPost")
+            .SelectMany(e => ((XmlSchemaComplexType)e.SchemaType!).ContentTypeParticle is XmlSchemaSequence seq ? seq.Items.OfType<XmlSchemaElement>().Select(el => el.Name) : [])
+            .ToArray();
+    }
+
+    public XmlDocument Generate(Dictionary<string, string?> values)
+    {
+        var doc = new XmlDocument();
+        doc.Schemas.Add(_schemas);
+
+        var root = doc.CreateElement("AltaIndPost");
+        doc.AppendChild(root);
+
+        foreach (var kv in values)
+        {
+            if (!_allowedElements.Contains(kv.Key))
+                continue;
+
+            var elem = doc.CreateElement(kv.Key);
+            if (kv.Value != null)
+            {
+                elem.InnerText = kv.Value;
+            }
+            root.AppendChild(elem);
+        }
+
+        // validate document
+        doc.Validate(null);
+        return doc;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `IIndPostXmlService` interface
- implement `IndPostXmlService` to create XML that complies with `IndPost.xsd`
- register service in DI container

## Testing
- `dotnet build Logibooks.sln -c Release`
- `dotnet test Logibooks.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6883e5df3cd08321a02283bc8a76494f