### PR TITLE
Add NextOrder endpoint

### DIFF
--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -1529,13 +1529,13 @@ public class RegistersControllerTests
     {
         SetCurrentUserId(1);
         _dbContext.CheckStatuses.Add(new OrderCheckStatus { Id = 101, Title = "Has" });
-        var reg = new Register { Id = 1, FileName = "r.xlsx", CompanyId = 2 };
+        var reg = new Register { Id = 1, FileName = "r.xlsx", CompanyId = 1 }; // Ozon company
         _dbContext.Registers.Add(reg);
-        _dbContext.Orders.AddRange(
-            new WbrOrder { Id = 1, RegisterId = 1, StatusId = 1, CheckStatusId = 101 },
-            new WbrOrder { Id = 2, RegisterId = 1, StatusId = 1, CheckStatusId = 201 },
-            new WbrOrder { Id = 3, RegisterId = 1, StatusId = 1, CheckStatusId = 101 }
-        );
+        var ozonOrder1 = new OzonOrder { Id = 1, RegisterId = 1, StatusId = 1, CheckStatusId = 101 };
+        var ozonOrder2 = new OzonOrder { Id = 2, RegisterId = 1, StatusId = 1, CheckStatusId = 201 };
+        var ozonOrder3 = new OzonOrder { Id = 3, RegisterId = 1, StatusId = 1, CheckStatusId = 101 };
+        _dbContext.Orders.AddRange(ozonOrder1, ozonOrder2, ozonOrder3);
+        _dbContext.OzonOrders.AddRange(ozonOrder1, ozonOrder2, ozonOrder3);
         await _dbContext.SaveChangesAsync();
 
         var result = await _controller.NextOrder(3);
@@ -1580,5 +1580,6 @@ public class RegistersControllerTests
         var obj = result.Result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
     }
+
 }
 

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -1501,5 +1501,84 @@ public class RegistersControllerTests
         var orderReloaded = await _dbContext.Orders.Include(o => o.BaseOrderFeacnPrefixes).FirstAsync(o => o.Id == 201);
         Assert.That(orderReloaded.BaseOrderFeacnPrefixes.Any(l => l.FeacnPrefixId == 400), Is.True);
     }
+
+    [Test]
+    public async Task NextOrder_ReturnsNextOrder_AfterGiven()
+    {
+        SetCurrentUserId(1);
+        _dbContext.CheckStatuses.AddRange(
+            new OrderCheckStatus { Id = 101, Title = "Has" },
+            new OrderCheckStatus { Id = 201, Title = "Ok" });
+        var reg = new Register { Id = 1, FileName = "r.xlsx", CompanyId = 2 };
+        _dbContext.Registers.Add(reg);
+        _dbContext.Orders.AddRange(
+            new WbrOrder { Id = 10, RegisterId = 1, StatusId = 1, CheckStatusId = 101 },
+            new WbrOrder { Id = 20, RegisterId = 1, StatusId = 1, CheckStatusId = 101 },
+            new WbrOrder { Id = 30, RegisterId = 1, StatusId = 1, CheckStatusId = 201 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.NextOrder(10);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Id, Is.EqualTo(20));
+    }
+
+    [Test]
+    public async Task NextOrder_PerformsCircularSearch()
+    {
+        SetCurrentUserId(1);
+        _dbContext.CheckStatuses.Add(new OrderCheckStatus { Id = 101, Title = "Has" });
+        var reg = new Register { Id = 1, FileName = "r.xlsx", CompanyId = 2 };
+        _dbContext.Registers.Add(reg);
+        _dbContext.Orders.AddRange(
+            new WbrOrder { Id = 1, RegisterId = 1, StatusId = 1, CheckStatusId = 101 },
+            new WbrOrder { Id = 2, RegisterId = 1, StatusId = 1, CheckStatusId = 201 },
+            new WbrOrder { Id = 3, RegisterId = 1, StatusId = 1, CheckStatusId = 101 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.NextOrder(3);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Id, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task NextOrder_ReturnsNoContent_WhenNoMatches()
+    {
+        SetCurrentUserId(1);
+        _dbContext.CheckStatuses.Add(new OrderCheckStatus { Id = 201, Title = "Ok" });
+        var reg = new Register { Id = 1, FileName = "r.xlsx", CompanyId = 2 };
+        _dbContext.Registers.Add(reg);
+        _dbContext.Orders.Add(new WbrOrder { Id = 1, RegisterId = 1, StatusId = 1, CheckStatusId = 201 });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.NextOrder(1);
+
+        Assert.That(result.Result, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task NextOrder_ReturnsNotFound_WhenOrderMissing()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.NextOrder(99);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task NextOrder_ReturnsForbidden_ForNonLogist()
+    {
+        SetCurrentUserId(2);
+        var result = await _controller.NextOrder(1);
+
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
 }
 

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -580,8 +580,8 @@ public class RegistersController(
 
         if (order == null)
         {
-            _logger.LogDebug("NextOrder returning '404 Not Found' - derived order not found");
-            return _404Order(next.Id);
+            _logger.LogDebug("NextOrder returning '204 No Content' - derived order not found");
+            return NoContent();
         }
 
         _logger.LogDebug("NextOrder returning order {id}", order.Id);

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -553,8 +553,10 @@ public class RegistersController(
                         o.CheckStatusId >= 101 && o.CheckStatusId < 200)
             .OrderBy(o => o.Id);
 
-        var next = await query.FirstOrDefaultAsync(o => o.Id > orderId) ??
-                   await query.FirstOrDefaultAsync(o => o.Id < orderId);
+        var next = await query
+            .OrderBy(o => o.Id > orderId ? 0 : 1) // Prioritize Id > orderId
+            .ThenBy(o => o.Id)                   // Then order by Id
+            .FirstOrDefaultAsync();
 
         if (next == null)
         {


### PR DESCRIPTION
## Summary
- implement `NextOrder` endpoint in `RegistersController`
- add unit tests for new controller method
- install dotnet 8 in test run

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_68868b1940388321b7a2da80e3376b22