### PR TITLE
Add register download endpoint

### DIFF
--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -534,14 +534,14 @@ public class RegistersController(
             return _403();
         }
 
-        var register = await _db.Registers.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id);
+        var register = await _db.Registers.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
         if (register == null)
         {
             _logger.LogDebug("DownloadRegister returning '404 Not Found'");
             return _404Register(id);
         }
 
-        var bytes = await _processingService.DownloadRegisterToExcelAsync(id);
+        var bytes = await _processingService.DownloadRegisterToExcelAsync(id, cancellationToken);
         var fileName = register.FileName;
 
         return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileName);

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -534,14 +534,14 @@ public class RegistersController(
             return _403();
         }
 
-        var register = await _db.Registers.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+        var register = await _db.Registers.AsNoTracking().FirstOrDefaultAsync(r => r.Id == id);
         if (register == null)
         {
             _logger.LogDebug("DownloadRegister returning '404 Not Found'");
             return _404Register(id);
         }
 
-        var bytes = await _processingService.DownloadRegisterToExcelAsync(id, cancellationToken);
+        var bytes = await _processingService.DownloadRegisterToExcelAsync(id);
         var fileName = register.FileName;
 
         return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileName);


### PR DESCRIPTION
## Summary
- implement `RegistersController.DownloadRegister`
- allow logist users to download registers as Excel files
- test download controller logic

## Testing
- `dotnet test Logibooks.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6886a7f74b848321b3d49ac98cb90dff