### PR TITLE
Add register archive generation endpoint

### DIFF
--- a/Logibooks.Core.Tests/Controllers/RegistersControllerSearchTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerSearchTests.cs
@@ -57,6 +57,7 @@ public class RegistersControllerSearchTests
     private User _adminUser;
     private RegistersController _controller;
     private Mock<IRegisterProcessingService> _mockProcessingService;
+    private Mock<IOrderIndPostGenerator> _mockIndPostGenerator;
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     private readonly string testDataDir = Path.Combine(AppContext.BaseDirectory, "test.data");
 
@@ -137,9 +138,10 @@ public class RegistersControllerSearchTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockRegValidationService = new Mock<IRegisterValidationService>();
         _mockProcessingService = new Mock<IRegisterProcessingService>();
+        _mockIndPostGenerator = new Mock<IOrderIndPostGenerator>();
         _logger = new LoggerFactory().CreateLogger<RegistersController>();
         _userService = new UserInformationService(_dbContext);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     private void SetCurrentUserId(int id)
@@ -147,7 +149,7 @@ public class RegistersControllerSearchTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     [Test]

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerSortingTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerSortingTests.cs
@@ -58,6 +58,7 @@ public class RegistersControllerSortingTests
     private User _adminUser;
     private RegistersController _controller;
     private Mock<IRegisterProcessingService> _mockProcessingService;
+    private Mock<IOrderIndPostGenerator> _mockIndPostGenerator;
 #pragma warning restore CS8618
     private readonly string testDataDir = Path.Combine(AppContext.BaseDirectory, "test.data");
 
@@ -132,9 +133,10 @@ public class RegistersControllerSortingTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockRegValidationService = new Mock<IRegisterValidationService>();
         _mockProcessingService = new Mock<IRegisterProcessingService>();
+        _mockIndPostGenerator = new Mock<IOrderIndPostGenerator>();
         _logger = new LoggerFactory().CreateLogger<RegistersController>();
         _userService = new UserInformationService(_dbContext);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     private void SetCurrentUserId(int id)
@@ -142,7 +144,7 @@ public class RegistersControllerSortingTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     // Move all sorting-related tests here and add new ones for extended sorting

--- a/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/RegistersControllerTests.cs
@@ -61,6 +61,7 @@ public class RegistersControllerTests
     private User _adminUser;
     private RegistersController _controller;
     private Mock<IRegisterProcessingService> _mockProcessingService;
+    private Mock<IOrderIndPostGenerator> _mockIndPostGenerator;
 #pragma warning restore CS8618
 
     private readonly string testDataDir = Path.Combine(AppContext.BaseDirectory, "test.data");
@@ -144,9 +145,10 @@ public class RegistersControllerTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockRegValidationService = new Mock<IRegisterValidationService>();
         _mockProcessingService = new Mock<IRegisterProcessingService>();
+        _mockIndPostGenerator = new Mock<IOrderIndPostGenerator>();
         _logger = new LoggerFactory().CreateLogger<RegistersController>();
         _userService = new UserInformationService(_dbContext);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     [TearDown]
@@ -161,7 +163,7 @@ public class RegistersControllerTests
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     [Test]
@@ -1482,7 +1484,7 @@ public class RegistersControllerTests
 
         // Update the logger type to match the expected type for RegisterValidationService
         var realRegSvc = new RegisterValidationService(_dbContext, scopeFactoryMock.Object, new LoggerFactory().CreateLogger<RegisterValidationService>(), new MorphologySearchService(), new FeacnPrefixCheckService(_dbContext));
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, realRegSvc, _mockProcessingService.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, realRegSvc, _mockProcessingService.Object, _mockIndPostGenerator.Object);
 
         var result = await _controller.ValidateRegister(200);
         var handle = ((GuidReference)((OkObjectResult)result.Result!).Value!).Id;
@@ -1707,6 +1709,55 @@ public class RegistersControllerTests
         var obj = result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
         _mockProcessingService.Verify(s => s.DownloadRegisterToExcelAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Generate_ReturnsFile_ForLogist()
+    {
+        SetCurrentUserId(1);
+        var register = new Register { Id = 20, FileName = "r.xlsx", CompanyId = 2 };
+        _dbContext.Registers.Add(register);
+        await _dbContext.SaveChangesAsync();
+
+        byte[] zip = [1, 2, 3, 4];
+        _mockIndPostGenerator.Setup(g => g.GenerateXML4R(20)).ReturnsAsync(("IndPost_r.zip", zip));
+
+        var result = await _controller.Generate(20);
+
+        Assert.That(result, Is.TypeOf<FileContentResult>());
+        var file = result as FileContentResult;
+        Assert.That(file!.FileDownloadName, Is.EqualTo("IndPost_r.zip"));
+        Assert.That(file.ContentType, Is.EqualTo("application/zip"));
+        Assert.That(file.FileContents, Is.EqualTo(zip));
+    }
+
+    [Test]
+    public async Task Generate_ReturnsNotFound_WhenMissing()
+    {
+        SetCurrentUserId(1);
+
+        var result = await _controller.Generate(999);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+        _mockIndPostGenerator.Verify(g => g.GenerateXML4R(It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Generate_ReturnsForbidden_ForNonLogist()
+    {
+        SetCurrentUserId(2);
+        var register = new Register { Id = 21, FileName = "r.xlsx", CompanyId = 2 };
+        _dbContext.Registers.Add(register);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Generate(21);
+
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+        _mockIndPostGenerator.Verify(g => g.GenerateXML4R(It.IsAny<int>()), Times.Never);
     }
 
 }


### PR DESCRIPTION
## Summary
- add dependency for order IndPost generator to RegistersController
- implement `Generate` endpoint to produce archive
- adjust tests for RegistersController to support new dependency
- add unit tests for generating register archive

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_688a76d6e7788321a196b76dc94478bc