### PR TITLE
Support weak morphology search

### DIFF
--- a/Logibooks.Core.Tests/Services/MorphologySearchServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/MorphologySearchServiceTests.cs
@@ -47,16 +47,25 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_FindsDerivativeMatch()
     {
-        var sw = new StopWord { Id = 1, Word = "золото" };
+        var sw = new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         var res = _service.CheckText(ctx, "золотой браслет и алюминиевый слиток");
         Assert.That(res.Contains(1));
     }
 
     [Test]
+    public void CheckText_FindsWeakFormMatch()
+    {
+        var sw = new StopWord { Id = 2, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.WeakMorphology };
+        var ctx = _service.InitializeContext([sw]);
+        var res = _service.CheckText(ctx, "работаем с золотом");
+        Assert.That(res.Contains(2));
+    }
+
+    [Test]
     public void InitializeContext_HandlesSingleStopWord()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         Assert.That(ctx, Is.Not.Null);
@@ -70,9 +79,9 @@ public class MorphologySearchServiceTests
     {
         var stopWords = new[]
         {
-            new StopWord { Id = 1, Word = "золото" },
-            new StopWord { Id = 2, Word = "серебро" },
-            new StopWord { Id = 3, Word = "дом" }
+            new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 2, Word = "серебро", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 3, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology }
         };
         
         var ctx = _service.InitializeContext(stopWords);
@@ -101,10 +110,10 @@ public class MorphologySearchServiceTests
     {
         var stopWords = new[]
         {
-            new StopWord { Id = 1, Word = "" },
-            new StopWord { Id = 2, Word = "   " },
-            new StopWord { Id = 3, Word = "золото" },
-            new StopWord { Id = 4, Word = null! }
+            new StopWord { Id = 1, Word = "", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 2, Word = "   ", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 3, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 4, Word = null!, MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology }
         };
         
         var ctx = _service.InitializeContext(stopWords);
@@ -119,7 +128,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesNullText()
     {
-        var sw = new StopWord { Id = 1, Word = "золото" };
+        var sw = new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, null!);
@@ -131,7 +140,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesEmptyText()
     {
-        var sw = new StopWord { Id = 1, Word = "золото" };
+        var sw = new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "");
@@ -143,7 +152,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesWhitespaceOnlyText()
     {
-        var sw = new StopWord { Id = 1, Word = "золото" };
+        var sw = new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "   \t\n  ");
@@ -157,8 +166,8 @@ public class MorphologySearchServiceTests
     {
         var stopWords = new[]
         {
-            new StopWord { Id = 1, Word = "золото" },
-            new StopWord { Id = 2, Word = "дом" }
+            new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 2, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology }
         };
         var ctx = _service.InitializeContext(stopWords);
         
@@ -171,7 +180,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_CaseInsensitive()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result1 = _service.CheckText(ctx, "большой ДОМ");
@@ -186,7 +195,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_NoMatchesForUnrelatedText()
     {
-        var sw = new StopWord { Id = 1, Word = "золото" };
+        var sw = new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "красивый автомобиль и зелёная трава");
@@ -197,7 +206,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesTextWithPunctuation()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "Это домашний, уютный и тёплый дом!");
@@ -208,7 +217,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesMixedLanguages()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "My beautiful домик is very nice house");
@@ -225,7 +234,7 @@ public class MorphologySearchServiceTests
     [TestCase("собака", "собачий корм", true)]
     public void CheckText_MorphologicalDerivatives(string stopWord, string testText, bool shouldMatch)
     {
-        var sw = new StopWord { Id = 1, Word = stopWord };
+        var sw = new StopWord { Id = 1, Word = stopWord, MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, testText);
@@ -243,7 +252,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_ReturnsUniqueIds()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "домашний дом и домик").ToList();
@@ -255,7 +264,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesLongText()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var longText = string.Join(" ", Enumerable.Repeat("Это очень длинный текст с множеством слов", 100)) 
@@ -282,9 +291,9 @@ public class MorphologySearchServiceTests
         var stopWords = new List<StopWord>();
         for (int i = 1; i <= 100; i++)
         {
-            stopWords.Add(new StopWord { Id = i, Word = $"слово{i}" });
+            stopWords.Add(new StopWord { Id = i, Word = $"слово{i}", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology });
         }
-        stopWords.Add(new StopWord { Id = 101, Word = "дом" });
+        stopWords.Add(new StopWord { Id = 101, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology });
         
         var ctx = _service.InitializeContext(stopWords);
         
@@ -296,7 +305,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesSpecialCharacters()
     {
-        var sw = new StopWord { Id = 1, Word = "дом" };
+        var sw = new StopWord { Id = 1, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "дом@example.com и домик#123 плюс дом$");
@@ -309,9 +318,9 @@ public class MorphologySearchServiceTests
     {
         var stopWords = new[]
         {
-            new StopWord { Id = 1, Word = "ЗОЛОТО" },
-            new StopWord { Id = 2, Word = "дом" },
-            new StopWord { Id = 3, Word = "УЧИТЬ" }
+            new StopWord { Id = 1, Word = "ЗОЛОТО", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 2, Word = "дом", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology },
+            new StopWord { Id = 3, Word = "УЧИТЬ", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology }
         };
         
         var ctx = _service.InitializeContext(stopWords);
@@ -326,7 +335,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_FindsExactMatch()
     {
-        var sw = new StopWord { Id = 1, Word = "золото" };
+        var sw = new StopWord { Id = 1, Word = "золото", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "чистое золото");
@@ -337,7 +346,7 @@ public class MorphologySearchServiceTests
     [Test]
     public void CheckText_HandlesVeryShortWords()
     {
-        var sw = new StopWord { Id = 1, Word = "я" };
+        var sw = new StopWord { Id = 1, Word = "я", MatchTypeId = (int)StopWordMatchTypeCode.StrongMorphology };
         var ctx = _service.InitializeContext([sw]);
         
         var result = _service.CheckText(ctx, "я иду домой");

--- a/Logibooks.Core.Tests/Services/OrderValidationServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/OrderValidationServiceTests.cs
@@ -168,7 +168,7 @@ public class OrderValidationServiceTests
         await ctx.SaveChangesAsync();
 
         var morph = new MorphologySearchService();
-        var morphologyContext = morph.InitializeContext(stopWords.Where(sw => sw.MatchTypeId == (int)StopWordMatchTypeCode.StrongMorphology));
+        var morphologyContext = morph.InitializeContext(stopWords.Where(sw => sw.MatchTypeId >= (int)StopWordMatchTypeCode.MorphologyMatchTypes));
         var svc = CreateServiceWithMorphology(ctx, morph);
         var stopWordsContext = svc.InitializeStopWordsContext(stopWords.Where(sw => sw.MatchTypeId == (int)StopWordMatchTypeCode.ExactSymbols));
         await svc.ValidateAsync(order, morphologyContext, stopWordsContext);

--- a/Logibooks.Core/Controllers/OrdersController.cs
+++ b/Logibooks.Core/Controllers/OrdersController.cs
@@ -375,8 +375,10 @@ public class OrdersController(
         }
 
         var stopWords = await _db.StopWords.AsNoTracking().ToListAsync();
-        var morphologyContext = _morphologyService.InitializeContext(stopWords.Where(sw => sw.MatchTypeId == (int)StopWordMatchTypeCode.StrongMorphology));
-        var stopWordsContext = _validationService.InitializeStopWordsContext(stopWords.Where(sw => sw.MatchTypeId == (int)StopWordMatchTypeCode.ExactSymbols));
+        var morphologyContext = _morphologyService.InitializeContext(
+            stopWords.Where(sw => sw.MatchTypeId >= (int)StopWordMatchTypeCode.MorphologyMatchTypes));
+        var stopWordsContext = _validationService.InitializeStopWordsContext(
+            stopWords.Where(sw => sw.MatchTypeId == (int)StopWordMatchTypeCode.ExactSymbols));
 
         await _validationService.ValidateAsync(order, morphologyContext, stopWordsContext, null);
 

--- a/Logibooks.Core/Services/IMorphologySearchService.cs
+++ b/Logibooks.Core/Services/IMorphologySearchService.cs
@@ -36,5 +36,6 @@ public interface IMorphologySearchService
 
 public class MorphologyContext
 {
+    internal Dictionary<string, HashSet<int>> NormalForms { get; } = new();
     internal Dictionary<Pullenti.Semantic.Utils.DerivateGroup, HashSet<int>> Groups { get; } = new();
 }

--- a/Logibooks.Core/Services/MorphologySearchService.cs
+++ b/Logibooks.Core/Services/MorphologySearchService.cs
@@ -68,24 +68,36 @@ public class MorphologySearchService : IMorphologySearchService
         {
             if (string.IsNullOrWhiteSpace(sw.Word))
                 continue;
-                
-            // Get the normal form first, then find derivatives
+
             var normalForm = GetNormalForm(sw.Word);
-            var groups = DerivateService.FindDerivates(normalForm, true, Pullenti.Morph.MorphLang.RU);
-            if (groups == null || !groups.Any())
-                continue;
-                
-            foreach (var g in groups)
+
+            if (sw.MatchTypeId == (int)StopWordMatchTypeCode.WeakMorphology)
             {
-                if (g == null)
-                    continue;
-                    
-                if (!context.Groups.TryGetValue(g, out var ids))
+                if (!context.NormalForms.TryGetValue(normalForm, out var ids))
                 {
                     ids = new HashSet<int>();
-                    context.Groups[g] = ids;
+                    context.NormalForms[normalForm] = ids;
                 }
                 ids.Add(sw.Id);
+            }
+            else if (sw.MatchTypeId == (int)StopWordMatchTypeCode.StrongMorphology)
+            {
+                var groups = DerivateService.FindDerivates(normalForm, true, Pullenti.Morph.MorphLang.RU);
+                if (groups == null || !groups.Any())
+                    continue;
+
+                foreach (var g in groups)
+                {
+                    if (g == null)
+                        continue;
+
+                    if (!context.Groups.TryGetValue(g, out var ids))
+                    {
+                        ids = new HashSet<int>();
+                        context.Groups[g] = ids;
+                    }
+                    ids.Add(sw.Id);
+                }
             }
         }
         return context;
@@ -93,31 +105,42 @@ public class MorphologySearchService : IMorphologySearchService
 
     public IEnumerable<int> CheckText(MorphologyContext context, string text)
     {
-        if (context?.Groups == null || !context.Groups.Any())
+        if ((context?.Groups == null || !context.Groups.Any()) &&
+            (context?.NormalForms == null || !context.NormalForms.Any()))
             return Enumerable.Empty<int>();
-            
+
         var result = new HashSet<int>();
         var matches = WordRegex.Matches(text ?? string.Empty);
-        
+
         foreach (Match m in matches)
         {
             if (string.IsNullOrWhiteSpace(m.Value))
                 continue;
-                
+
             // Get the normal form first, then find derivatives
-            var normalForm = GetNormalForm(m.Value);
-            var tokenGroups = DerivateService.FindDerivates(normalForm, true, Pullenti.Morph.MorphLang.RU);
-            if (tokenGroups == null || !tokenGroups.Any())
-                continue;
-                
-            foreach (var g in tokenGroups)
+            var morphs = MorphologyService.GetAllWordforms(m.Value.ToUpperInvariant(), Pullenti.Morph.MorphLang.RU);
+            var normalForm = morphs.Count > 0 ? morphs.First().NormalCase.ToUpperInvariant() : m.Value.ToUpperInvariant();
+
+            foreach (var nf in morphs.Select(f => f.NormalCase.ToUpperInvariant()).Append(normalForm).Distinct())
             {
-                if (g == null)
-                    continue;
-                    
-                if (context.Groups.TryGetValue(g, out var ids))
+                if (context.NormalForms.TryGetValue(nf, out var ids))
                 {
                     result.UnionWith(ids);
+                }
+            }
+
+            var tokenGroups = DerivateService.FindDerivates(normalForm, true, Pullenti.Morph.MorphLang.RU);
+            if (tokenGroups != null)
+            {
+                foreach (var g in tokenGroups)
+                {
+                    if (g == null)
+                        continue;
+
+                    if (context.Groups.TryGetValue(g, out var ids))
+                    {
+                        result.UnionWith(ids);
+                    }
                 }
             }
         }

--- a/Logibooks.Core/Services/RegisterValidationService.cs
+++ b/Logibooks.Core/Services/RegisterValidationService.cs
@@ -70,7 +70,8 @@ public class RegisterValidationService(
         _byHandle[process.HandleId] = process;
 
         var allStopWords = await _db.StopWords.AsNoTracking().ToListAsync(cancellationToken);
-        var morphologyContext = _morphologyService.InitializeContext(allStopWords.Where(sw => sw.MatchTypeId == (int)StopWordMatchTypeCode.StrongMorphology));
+        var morphologyContext = _morphologyService.InitializeContext(
+            allStopWords.Where(sw => sw.MatchTypeId >= (int)StopWordMatchTypeCode.MorphologyMatchTypes));
 
         var tcs = new TaskCompletionSource();
 


### PR DESCRIPTION
## Summary
- extend `MorphologyContext` with a normal form dictionary
- distinguish weak and strong morphology in `MorphologySearchService`
- match every word form when searching text
- include all morphology match types when validating orders and registers
- update tests for new behaviour and add a weak-form test

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_688aa7136a0083218311bd374f7899f0