### PR TITLE
Add destination and origin country sorting for registers

### DIFF
--- a/Logibooks.Core.Tests/Controllers/Registers/RegistersControllerSearchTests.cs
+++ b/Logibooks.Core.Tests/Controllers/Registers/RegistersControllerSearchTests.cs
@@ -213,6 +213,36 @@ public class RegistersControllerSearchTests : RegistersControllerTestsBase
     }
 
     [Test]
+    public async Task GetRegisters_SearchWithEmptyString_ReturnsAll()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Registers.AddRange(
+            new Register { Id = 1, FileName = "r1.xlsx", CompanyId = 2, TheOtherCompanyId = 3 },
+            new Register { Id = 2, FileName = "r2.xlsx", CompanyId = 2, TheOtherCompanyId = 3 }
+        );
+        await _dbContext.SaveChangesAsync();
+        var result = await _controller.GetRegisters(search: string.Empty);
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<RegisterViewItem>;
+        Assert.That(pr!.Pagination.TotalCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetRegisters_SearchWithWhitespace_ReturnsAll()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Registers.AddRange(
+            new Register { Id = 1, FileName = "r1.xlsx", CompanyId = 2, TheOtherCompanyId = 3 },
+            new Register { Id = 2, FileName = "r2.xlsx", CompanyId = 2, TheOtherCompanyId = 3 }
+        );
+        await _dbContext.SaveChangesAsync();
+        var result = await _controller.GetRegisters(search: "   ");
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<RegisterViewItem>;
+        Assert.That(pr!.Pagination.TotalCount, Is.EqualTo(2));
+    }
+
+    [Test]
     public async Task GetRegisters_SearchReturnsZeroWhenNoMatch()
     {
         SetCurrentUserId(1);

--- a/Logibooks.Core.Tests/Controllers/Registers/RegistersControllerSortingTests.cs
+++ b/Logibooks.Core.Tests/Controllers/Registers/RegistersControllerSortingTests.cs
@@ -255,6 +255,44 @@ public class RegistersControllerSortingTests : RegistersControllerTestsBase
         Assert.That(items[1].Id, Is.EqualTo(1));
     }
 
+    // Sorting by Destination Country ascending
+    [Test]
+    public async Task GetRegisters_SortsByDestCountryCode_Ascending()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Registers.AddRange(
+            new Register { Id = 1, FileName = "r1.xlsx", CompanyId = 2, TheOtherCompanyId = 3, CustomsProcedureId = 1, TheOtherCountryCode = 860 },
+            new Register { Id = 2, FileName = "r2.xlsx", CompanyId = 2, TheOtherCompanyId = 3, CustomsProcedureId = 2, TheOtherCountryCode = 860 }
+        );
+        await _dbContext.SaveChangesAsync();
+        var result = await _controller.GetRegisters(sortBy: "destcountrycode", sortOrder: "asc");
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<RegisterViewItem>;
+        var items = pr!.Items.ToArray();
+        // Register 2 should come first (destination is Россия)
+        Assert.That(items[0].Id, Is.EqualTo(2));
+        Assert.That(items[1].Id, Is.EqualTo(1));
+    }
+
+    // Sorting by Origin Country descending
+    [Test]
+    public async Task GetRegisters_SortsByOrigCountryCode_Descending()
+    {
+        SetCurrentUserId(1);
+        _dbContext.Registers.AddRange(
+            new Register { Id = 1, FileName = "r1.xlsx", CompanyId = 2, TheOtherCompanyId = 3, CustomsProcedureId = 1, TheOtherCountryCode = 860 },
+            new Register { Id = 2, FileName = "r2.xlsx", CompanyId = 2, TheOtherCompanyId = 3, CustomsProcedureId = 2, TheOtherCountryCode = 860 }
+        );
+        await _dbContext.SaveChangesAsync();
+        var result = await _controller.GetRegisters(sortBy: "origcountrycode", sortOrder: "desc");
+        var ok = result.Result as OkObjectResult;
+        var pr = ok!.Value as PagedResult<RegisterViewItem>;
+        var items = pr!.Items.ToArray();
+        // Register 2 has origin Узбекистан, should come first in descending order
+        Assert.That(items[0].Id, Is.EqualTo(2));
+        Assert.That(items[1].Id, Is.EqualTo(1));
+    }
+
     // Test for invalid sort field
     [Test]
     public async Task GetRegisters_ReturnsBadRequest_WhenSortByIsInvalid()

--- a/Logibooks.Core/Constants/CountryConstants.cs
+++ b/Logibooks.Core/Constants/CountryConstants.cs
@@ -1,0 +1,49 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+namespace Logibooks.Core.Constants;
+
+public static class CountryConstants
+{
+    /// <summary>
+    /// ISO Numeric code for Russia (643)
+    /// </summary>
+    public const short RussiaIsoNumeric = 643;
+
+    /// <summary>
+    /// ISO Alpha-2 code for Russia (RU)
+    /// </summary>
+    public const string RussiaIsoAlpha2 = "RU";
+
+    /// <summary>
+    /// Short Russian name for Russia (Россия)
+    /// </summary>
+    public const string RussiaNameRuShort = "Россия";
+
+    /// <summary>
+    /// Official Russian name for Russia (Российская Федерация)
+    /// </summary>
+    public const string RussiaNameRuOfficial = "Российская Федерация";
+}

--- a/Logibooks.Core/Constants/CountryConstants.cs
+++ b/Logibooks.Core/Constants/CountryConstants.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+п»ї// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
 // This file is a part of Logibooks Core application
 //
@@ -38,12 +38,12 @@ public static class CountryConstants
     public const string RussiaIsoAlpha2 = "RU";
 
     /// <summary>
-    /// Short Russian name for Russia (Россия)
+    /// Short Russian name for Russia (Р РѕСЃСЃРёСЏ)
     /// </summary>
-    public const string RussiaNameRuShort = "Россия";
+    public const string RussiaNameRuShort = "Р РѕСЃСЃРёСЏ";
 
     /// <summary>
-    /// Official Russian name for Russia (Российская Федерация)
+    /// Official Russian name for Russia (Р РѕСЃСЃРёР№СЃРєР°СЏ Р¤РµРґРµСЂР°С†РёСЏ)
     /// </summary>
-    public const string RussiaNameRuOfficial = "Российская Федерация";
+    public const string RussiaNameRuOfficial = "Р РѕСЃСЃРёР№СЃРєР°СЏ Р¤РµРґРµСЂР°С†РёСЏ";
 }

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -86,6 +86,26 @@ public class RegistersController(
                     : (r.TheOtherCompany != null ? (r.TheOtherCompany.ShortName ?? string.Empty) : string.Empty));
     }
 
+    private static Expression<Func<Register, string>> CountrySortSelector(bool byDestination)
+    {
+        return r =>
+            r.CustomsProcedure != null && r.CustomsProcedure.Code == 10
+                ? (byDestination
+                    ? (r.TheOtherCountryCode == null
+                        ? string.Empty
+                        : r.TheOtherCountryCode == 643
+                            ? "Россия"
+                            : (r.TheOtherCountry != null ? (r.TheOtherCountry.NameRuShort ?? string.Empty) : string.Empty))
+                    : "Россия")
+                : (byDestination
+                    ? "Россия"
+                    : (r.TheOtherCountryCode == null
+                        ? string.Empty
+                        : r.TheOtherCountryCode == 643
+                            ? "Россия"
+                            : (r.TheOtherCountry != null ? (r.TheOtherCountry.NameRuShort ?? string.Empty) : string.Empty)));
+    }
+
     [HttpGet("{id}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RegisterViewItem))]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
@@ -208,6 +228,10 @@ public class RegistersController(
             ("recipientid", "desc") => query.OrderByDescending(PartySortSelector(true)),
             ("senderid", "asc") => query.OrderBy(PartySortSelector(false)),
             ("senderid", "desc") => query.OrderByDescending(PartySortSelector(false)),
+            ("destcountrycode", "asc") => query.OrderBy(CountrySortSelector(true)),
+            ("destcountrycode", "desc") => query.OrderByDescending(CountrySortSelector(true)),
+            ("origcountrycode", "asc") => query.OrderBy(CountrySortSelector(false)),
+            ("origcountrycode", "desc") => query.OrderByDescending(CountrySortSelector(false)),
             ("theothercountrycode", "asc") => query.OrderBy(r => r.TheOtherCountry != null ? r.TheOtherCountry.NameRuShort : string.Empty),
             ("theothercountrycode", "desc") => query.OrderByDescending(r => r.TheOtherCountry != null ? r.TheOtherCountry.NameRuShort : string.Empty),
             ("transportationtypeid", "asc") => query.OrderBy(r => r.TransportationType != null ? r.TransportationType.Name : string.Empty),

--- a/Logibooks.Core/Controllers/RegistersController.cs
+++ b/Logibooks.Core/Controllers/RegistersController.cs
@@ -29,6 +29,7 @@ using SharpCompress.Archives;
 using System.Linq.Expressions;
 
 using Logibooks.Core.Authorization;
+using Logibooks.Core.Constants;
 using Logibooks.Core.Data;
 using Logibooks.Core.Models;
 using Logibooks.Core.RestModels;
@@ -93,16 +94,16 @@ public class RegistersController(
                 ? (byDestination
                     ? (r.TheOtherCountryCode == null
                         ? string.Empty
-                        : r.TheOtherCountryCode == 643
-                            ? "Россия"
+                        : r.TheOtherCountryCode == CountryConstants.RussiaIsoNumeric
+                            ? CountryConstants.RussiaNameRuShort
                             : (r.TheOtherCountry != null ? (r.TheOtherCountry.NameRuShort ?? string.Empty) : string.Empty))
-                    : "Россия")
+                    : CountryConstants.RussiaNameRuShort)
                 : (byDestination
-                    ? "Россия"
+                    ? CountryConstants.RussiaNameRuShort
                     : (r.TheOtherCountryCode == null
                         ? string.Empty
-                        : r.TheOtherCountryCode == 643
-                            ? "Россия"
+                        : r.TheOtherCountryCode == CountryConstants.RussiaIsoNumeric
+                            ? CountryConstants.RussiaNameRuShort
                             : (r.TheOtherCountry != null ? (r.TheOtherCountry.NameRuShort ?? string.Empty) : string.Empty)));
     }
 
@@ -193,7 +194,7 @@ public class RegistersController(
 
         if (!string.IsNullOrWhiteSpace(search))
         {           
-            if (!"россия".Contains(search, StringComparison.OrdinalIgnoreCase))
+            if (!CountryConstants.RussiaNameRuShort.Contains(search, StringComparison.OrdinalIgnoreCase))
             {
                 baseQuery = baseQuery.Where(r => 
                        EF.Functions.Like(r.FileName, $"%{search}%")


### PR DESCRIPTION
## Summary
- add `CountrySortSelector` helper and support sorting registers by destination and origin country
- extend sorting tests to cover new modes
- increase search test coverage with empty and whitespace queries

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_688f808a38cc8321942e5e9d294e831f