### PR TITLE
Add KeyWords controller with admin-protected CRUD

### DIFF
--- a/Logibooks.Core.Tests/Controllers/KeyWordsControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/KeyWordsControllerTests.cs
@@ -1,0 +1,180 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using System.Linq;
+using System.Threading.Tasks;
+
+using Moq;
+using NUnit.Framework;
+
+using Logibooks.Core.Controllers;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
+
+namespace Logibooks.Core.Tests.Controllers;
+
+[TestFixture]
+public class KeyWordsControllerTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private ILogger<KeyWordsController> _logger;
+    private IUserInformationService _userService;
+    private KeyWordsController _controller;
+    private Role _adminRole;
+    private Role _logistRole;
+    private User _adminUser;
+    private User _logistUser;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"key_words_controller_db_{System.Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+
+        _adminRole = new Role { Id = 1, Name = "administrator", Title = "Администратор" };
+        _logistRole = new Role { Id = 2, Name = "logist", Title = "Логист" };
+        _dbContext.Roles.AddRange(_adminRole, _logistRole);
+
+        string hpw = BCrypt.Net.BCrypt.HashPassword("pwd");
+        _adminUser = new User
+        {
+            Id = 1,
+            Email = "admin@example.com",
+            Password = hpw,
+            UserRoles = [new UserRole { UserId = 1, RoleId = 1, Role = _adminRole }]
+        };
+        _logistUser = new User
+        {
+            Id = 2,
+            Email = "logist@example.com",
+            Password = hpw,
+            UserRoles = [new UserRole { UserId = 2, RoleId = 2, Role = _logistRole }]
+        };
+        _dbContext.Users.AddRange(_adminUser, _logistUser);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _logger = new LoggerFactory().CreateLogger<KeyWordsController>();
+        _userService = new UserInformationService(_dbContext);
+        _controller = new KeyWordsController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    private void SetCurrentUserId(int id)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Items["UserId"] = id;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
+        _controller = new KeyWordsController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger);
+    }
+
+    [Test]
+    public async Task GetKeyWords_ReturnsAll_ForLogist()
+    {
+        SetCurrentUserId(2);
+        _dbContext.KeyWords.AddRange(new KeyWord { Id = 1, Word = "a" }, new KeyWord { Id = 2, Word = "b" });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetKeyWords();
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task CreateUpdateDelete_Work_ForAdmin()
+    {
+        SetCurrentUserId(1);
+        var dto = new KeyWordDto { Word = "test", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols, FeacnCode = "1234" };
+        var created = await _controller.PostKeyWord(dto);
+        Assert.That(created.Result, Is.TypeOf<CreatedAtActionResult>());
+        var createdDto = (created.Result as CreatedAtActionResult)!.Value as KeyWordDto;
+        Assert.That(createdDto!.Id, Is.GreaterThan(0));
+
+        var id = createdDto.Id;
+        createdDto.Word = "upd";
+        createdDto.FeacnCode = "5678";
+        var upd = await _controller.PutKeyWord(id, createdDto);
+        Assert.That(upd, Is.TypeOf<NoContentResult>());
+
+        var del = await _controller.DeleteKeyWord(id);
+        Assert.That(del, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task Create_ReturnsForbidden_ForNonAdmin()
+    {
+        SetCurrentUserId(2);
+        var dto = new KeyWordDto { Word = "w" };
+        var result = await _controller.PostKeyWord(dto);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Delete_ReturnsForbidden_ForNonAdmin()
+    {
+        SetCurrentUserId(1);
+        _dbContext.KeyWords.Add(new KeyWord { Id = 5, Word = "del" });
+        await _dbContext.SaveChangesAsync();
+        SetCurrentUserId(2);
+        var result = await _controller.DeleteKeyWord(5);
+        Assert.That(result, Is.TypeOf<ObjectResult>());
+        var obj = result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status403Forbidden));
+    }
+
+    [Test]
+    public async Task Create_ReturnsConflict_WhenWordExists()
+    {
+        SetCurrentUserId(1);
+        _dbContext.KeyWords.Add(new KeyWord { Id = 10, Word = "dup" });
+        await _dbContext.SaveChangesAsync();
+        var dto = new KeyWordDto { Word = "dup", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols };
+        var result = await _controller.PostKeyWord(dto);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status409Conflict));
+    }
+}

--- a/Logibooks.Core/Controllers/KeyWordsController.cs
+++ b/Logibooks.Core/Controllers/KeyWordsController.cs
@@ -68,7 +68,7 @@ public class KeyWordsController(
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(KeyWordDto))]
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
-    public async Task<ActionResult<KeyWordDto>> PostKeyWord(KeyWordDto dto)
+    public async Task<ActionResult<KeyWordDto>> CreateKeyWord(KeyWordDto dto)
     {
         if (!await _userService.CheckAdmin(_curUserId)) return _403();
 
@@ -87,7 +87,7 @@ public class KeyWordsController(
         }
         catch (DbUpdateException ex) when (ex.InnerException?.Message?.Contains("IX_key_words_word") == true)
         {
-            _logger.LogDebug("PostKeyWord returning '409 Conflict' due to database constraint");
+            _logger.LogDebug("CreateKeyWord returning '409 Conflict' due to database constraint");
             return _409KeyWord(dto.Word);
         }
     }
@@ -97,7 +97,7 @@ public class KeyWordsController(
     [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
     [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
-    public async Task<IActionResult> PutKeyWord(int id, KeyWordDto dto)
+    public async Task<IActionResult> UpdateKeyWord(int id, KeyWordDto dto)
     {
         if (!await _userService.CheckAdmin(_curUserId)) return _403();
         if (id != dto.Id) return BadRequest();
@@ -123,7 +123,7 @@ public class KeyWordsController(
         }
         catch (DbUpdateException ex) when (ex.InnerException?.Message?.Contains("IX_key_words_word") == true)
         {
-            _logger.LogDebug("PutKeyWord returning '409 Conflict' due to database constraint");
+            _logger.LogDebug("UpdateKeyWord returning '409 Conflict' due to database constraint");
             return _409KeyWord(dto.Word);
         }
     }

--- a/Logibooks.Core/Controllers/KeyWordsController.cs
+++ b/Logibooks.Core/Controllers/KeyWordsController.cs
@@ -1,0 +1,146 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using Logibooks.Core.Authorization;
+using Logibooks.Core.Data;
+using Logibooks.Core.RestModels;
+using Logibooks.Core.Services;
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+[ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrMessage))]
+public class KeyWordsController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    IUserInformationService userService,
+    ILogger<KeyWordsController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
+{
+    private readonly IUserInformationService _userService = userService;
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<KeyWordDto>))]
+    public async Task<ActionResult<IEnumerable<KeyWordDto>>> GetKeyWords()
+    {
+        var words = await _db.KeyWords.AsNoTracking().OrderBy(w => w.Id).ToListAsync();
+        return words.Select(w => new KeyWordDto(w)).ToList();
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(KeyWordDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<KeyWordDto>> GetKeyWord(int id)
+    {
+        var word = await _db.KeyWords.AsNoTracking().FirstOrDefaultAsync(w => w.Id == id);
+        return word == null ? _404Object(id) : new KeyWordDto(word);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(KeyWordDto))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<KeyWordDto>> PostKeyWord(KeyWordDto dto)
+    {
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
+
+        if (await _db.KeyWords.AnyAsync(sw => sw.Word.ToLower() == dto.Word.ToLower()))
+        {
+            return _409KeyWord(dto.Word);
+        }
+
+        var kw = dto.ToModel();
+        _db.KeyWords.Add(kw);
+        try
+        {
+            await _db.SaveChangesAsync();
+            dto.Id = kw.Id;
+            return CreatedAtAction(nameof(GetKeyWord), new { id = kw.Id }, dto);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException?.Message?.Contains("IX_key_words_word") == true)
+        {
+            _logger.LogDebug("PostKeyWord returning '409 Conflict' due to database constraint");
+            return _409KeyWord(dto.Word);
+        }
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> PutKeyWord(int id, KeyWordDto dto)
+    {
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
+        if (id != dto.Id) return BadRequest();
+
+        var kw = await _db.KeyWords.FindAsync(id);
+        if (kw == null) return _404Object(id);
+
+        if (!kw.Word.Equals(dto.Word, StringComparison.OrdinalIgnoreCase) &&
+            await _db.KeyWords.AnyAsync(w => w.Word.ToLower() == dto.Word.ToLower()))
+        {
+            return _409KeyWord(dto.Word);
+        }
+
+        kw.Word = dto.Word;
+        kw.MatchTypeId = dto.MatchTypeId;
+        kw.FeacnCode = dto.FeacnCode;
+
+        try
+        {
+            _db.Entry(kw).State = EntityState.Modified;
+            await _db.SaveChangesAsync();
+            return NoContent();
+        }
+        catch (DbUpdateException ex) when (ex.InnerException?.Message?.Contains("IX_key_words_word") == true)
+        {
+            _logger.LogDebug("PutKeyWord returning '409 Conflict' due to database constraint");
+            return _409KeyWord(dto.Word);
+        }
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrMessage))]
+    public async Task<IActionResult> DeleteKeyWord(int id)
+    {
+        if (!await _userService.CheckAdmin(_curUserId)) return _403();
+        var kw = await _db.KeyWords.FindAsync(id);
+        if (kw == null) return _404Object(id);
+
+        _db.KeyWords.Remove(kw);
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -141,6 +141,11 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
         return StatusCode(StatusCodes.Status409Conflict,
                           new ErrMessage { Msg = $"Стоп-слово уже существует [слово = {word}]" });
     }
+    protected ObjectResult _409KeyWord(string word)
+    {
+        return StatusCode(StatusCodes.Status409Conflict,
+                          new ErrMessage { Msg = $"Ключевое слово уже существует [слово = {word}]" });
+    }
     protected ObjectResult _500Mapping(string fname)
     {
         return StatusCode(StatusCodes.Status500InternalServerError,

--- a/Logibooks.Core/RestModels/KeyWordDto.cs
+++ b/Logibooks.Core/RestModels/KeyWordDto.cs
@@ -1,0 +1,57 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+namespace Logibooks.Core.RestModels;
+
+using Logibooks.Core.Models;
+
+public class KeyWordDto
+{
+    public int Id { get; set; }
+    public string Word { get; set; } = string.Empty;
+    public int MatchTypeId { get; set; }
+    public string FeacnCode { get; set; } = string.Empty;
+
+    public KeyWordDto() { }
+
+    public KeyWordDto(KeyWord kw)
+    {
+        Id = kw.Id;
+        Word = kw.Word;
+        MatchTypeId = kw.MatchTypeId;
+        FeacnCode = kw.FeacnCode;
+    }
+
+    public KeyWord ToModel()
+    {
+        return new KeyWord
+        {
+            Id = Id,
+            Word = Word,
+            MatchTypeId = MatchTypeId,
+            FeacnCode = FeacnCode
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- implement KeyWords controller and DTO with CRUD operations
- add role-based authorization and custom conflict error
- cover controller with tests

## Testing
- `dotnet test Logibooks.sln`


------
https://chatgpt.com/codex/tasks/task_e_689f13e4b19483219ec59d8fdad53c15