### PR TITLE
Add keyword Excel processing service

### DIFF
--- a/Logibooks.Core.Tests/Services/KeywordsProcessingServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/KeywordsProcessingServiceTests.cs
@@ -1,0 +1,85 @@
+using ClosedXML.Excel;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Logibooks.Core.Tests.Services;
+
+public class KeywordsProcessingServiceTests
+{
+# pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private KeywordsProcessingService _service;
+# pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"kw_{Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+        var logger = new LoggerFactory().CreateLogger<KeywordsProcessingService>();
+        _service = new KeywordsProcessingService(_dbContext, logger);
+    }
+
+    [Test]
+    public async Task UploadKeywordsFromExcelAsync_AddsUpdatesAndDeletes()
+    {
+        _dbContext.KeyWords.Add(new KeyWord { Id = 1, Word = "старый", MatchTypeId = (int)WordMatchTypeCode.WeakMorphology, FeacnCode = "1111111111" });
+        _dbContext.KeyWords.Add(new KeyWord { Id = 2, Word = "удалить", MatchTypeId = (int)WordMatchTypeCode.Phrase, FeacnCode = "2222222222" });
+        _dbContext.SaveChanges();
+
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Лист1");
+        ws.Cell(1, 1).Value = "код";
+        ws.Cell(1, 2).Value = "наименование";
+        ws.Cell(2, 1).Value = "1234567890";
+        ws.Cell(2, 2).Value = "старый, новый товар";
+        ws.Cell(3, 1).Value = "0987654321";
+        ws.Cell(3, 2).Value = "еще слово";
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        var content = ms.ToArray();
+
+        var result = await _service.UploadKeywordsFromExcelAsync(content, "test.xlsx");
+
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(_dbContext.KeyWords.Count(), Is.EqualTo(3));
+        Assert.That(_dbContext.KeyWords.Any(k => k.Word == "удалить"), Is.False);
+
+        var updated = _dbContext.KeyWords.Single(k => k.Word == "старый");
+        Assert.That(updated.FeacnCode, Is.EqualTo("1234567890"));
+        Assert.That(updated.MatchTypeId, Is.EqualTo((int)WordMatchTypeCode.WeakMorphology));
+
+        var phrase = _dbContext.KeyWords.Single(k => k.Word == "новый товар");
+        Assert.That(phrase.MatchTypeId, Is.EqualTo((int)WordMatchTypeCode.Phrase));
+        Assert.That(phrase.FeacnCode, Is.EqualTo("1234567890"));
+    }
+
+    [Test]
+    public void UploadKeywordsFromExcelAsync_InvalidCode_Throws()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.Worksheets.Add("Лист1");
+        ws.Cell(1, 1).Value = "код";
+        ws.Cell(1, 2).Value = "наименование";
+        ws.Cell(2, 1).Value = "12345"; // invalid
+        ws.Cell(2, 2).Value = "товар";
+        using var ms = new MemoryStream();
+        wb.SaveAs(ms);
+        var content = ms.ToArray();
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UploadKeywordsFromExcelAsync(content, "bad.xlsx"));
+        Assert.That(ex!.Message, Does.Contain("должен содержать ровно 10 цифр"));
+    }
+}
+

--- a/Logibooks.Core/Interfaces/IKeywordsProcessingService.cs
+++ b/Logibooks.Core/Interfaces/IKeywordsProcessingService.cs
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.Interfaces;
+
+public interface IKeywordsProcessingService
+{
+    Task<List<KeyWord>> UploadKeywordsFromExcelAsync(
+        byte[] content,
+        string fileName,
+        CancellationToken cancellationToken = default);
+}
+

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -60,6 +60,7 @@ builder.Services
     .AddScoped<IOrderValidationService, OrderValidationService>()
     .AddScoped<IRegisterValidationService, RegisterValidationService>()
     .AddScoped<IRegisterProcessingService, RegisterProcessingService>()
+    .AddScoped<IKeywordsProcessingService, KeywordsProcessingService>()
     .AddScoped<IIndPostXmlService, IndPostXmlService>()
     .AddScoped<IOrderIndPostGenerator, OrderIndPostGenerator>()
     .AddScoped<IUserInformationService, UserInformationService>()

--- a/Logibooks.Core/Services/KeywordsProcessingService.cs
+++ b/Logibooks.Core/Services/KeywordsProcessingService.cs
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using ExcelDataReader;
+using Logibooks.Core.Data;
+using Logibooks.Core.Interfaces;
+using Logibooks.Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Logibooks.Core.Services;
+
+public class KeywordsProcessingService(AppDbContext db, ILogger<KeywordsProcessingService> logger) : IKeywordsProcessingService
+{
+    private readonly AppDbContext _db = db;
+    private readonly ILogger<KeywordsProcessingService> _logger = logger;
+    private static readonly CultureInfo RussianCulture = new("ru-RU");
+
+    public async Task<List<KeyWord>> UploadKeywordsFromExcelAsync(
+        byte[] content,
+        string fileName,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+            using var ms = new MemoryStream(content);
+            using var reader = ExcelReaderFactory.CreateReader(ms);
+            var dataSet = reader.AsDataSet();
+            if (dataSet.Tables.Count == 0 || dataSet.Tables[0].Rows.Count == 0)
+                throw new InvalidOperationException("Excel файл пуст или не содержит данных");
+
+            var table = dataSet.Tables[0];
+            var header = table.Rows[0];
+            int codeCol = -1;
+            int nameCol = -1;
+            for (int c = 0; c < table.Columns.Count; c++)
+            {
+                var head = header[c]?.ToString()?.Trim().ToLower(RussianCulture);
+                if (head == "код")
+                    codeCol = c;
+                else if (head == "наименование")
+                    nameCol = c;
+            }
+
+            if (codeCol < 0 || nameCol < 0)
+                throw new InvalidOperationException("Не найдены столбцы 'код' и 'наименование'");
+
+            var parsed = new List<KeyWord>();
+            var regex = new Regex("^\\d{10}$");
+            for (int r = 1; r < table.Rows.Count; r++)
+            {
+                var code = table.Rows[r][codeCol]?.ToString()?.Trim() ?? string.Empty;
+                var name = table.Rows[r][nameCol]?.ToString() ?? string.Empty;
+                if (string.IsNullOrWhiteSpace(code) || string.IsNullOrWhiteSpace(name))
+                    continue;
+
+                if (!regex.IsMatch(code))
+                    throw new InvalidOperationException($"Код '{code}' в строке {r + 1} должен содержать ровно 10 цифр");
+
+                var words = name
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(w => w.Trim())
+                    .Where(w => !string.IsNullOrWhiteSpace(w))
+                    .Select(w => w.ToLower(RussianCulture));
+
+                foreach (var word in words)
+                {
+                    int matchType = word.Contains(' ')
+                        ? (int)WordMatchTypeCode.Phrase
+                        : (int)WordMatchTypeCode.WeakMorphology;
+                    parsed.Add(new KeyWord
+                    {
+                        Word = word,
+                        FeacnCode = code,
+                        MatchTypeId = matchType
+                    });
+                }
+            }
+
+            IDbContextTransaction? tx = null;
+            if (_db.Database.ProviderName != "Microsoft.EntityFrameworkCore.InMemory")
+                tx = await _db.Database.BeginTransactionAsync(cancellationToken);
+
+            var existing = await _db.KeyWords.ToListAsync(cancellationToken);
+            var existingDict = existing.ToDictionary(k => k.Word.ToLower(RussianCulture), k => k);
+            var incomingWords = new HashSet<string>(parsed.Select(p => p.Word), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var kw in parsed)
+            {
+                if (existingDict.TryGetValue(kw.Word, out var existingKw))
+                {
+                    existingKw.FeacnCode = kw.FeacnCode;
+                    existingKw.MatchTypeId = kw.MatchTypeId;
+                    _db.KeyWords.Update(existingKw);
+                }
+                else
+                {
+                    _db.KeyWords.Add(kw);
+                }
+            }
+
+            foreach (var kw in existing)
+            {
+                if (!incomingWords.Contains(kw.Word))
+                    _db.KeyWords.Remove(kw);
+            }
+
+            await _db.SaveChangesAsync(cancellationToken);
+            if (tx != null)
+                await tx.CommitAsync(cancellationToken);
+            return parsed;
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка обработки файла {File}", fileName);
+            throw new InvalidOperationException("Ошибка обработки файла ключевых слов", ex);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement KeywordsProcessingService to parse Excel files and sync keywords with database
- register KeywordsProcessingService in DI container
- cover keyword import logic with unit tests

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_689f4591b61c83219cb68a0c4c34337b