### PR TITLE
refactor: introduce WordBase for stop and key words

### DIFF
--- a/Logibooks.Core/Data/AppDbContext.cs
+++ b/Logibooks.Core/Data/AppDbContext.cs
@@ -56,6 +56,9 @@ namespace Logibooks.Core.Data
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.Entity<WordBase>()
+                .UseTpcMappingStrategy();
+
             modelBuilder.Entity<UserRole>()
                 .HasKey(ur => new { ur.UserId, ur.RoleId });
 

--- a/Logibooks.Core/Models/StopWord.cs
+++ b/Logibooks.Core/Models/StopWord.cs
@@ -25,23 +25,12 @@
 
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;
-using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace Logibooks.Core.Models;
 
 [Table("stop_words")]
 [Index(nameof(Word), IsUnique = true, Name = "IX_stop_words_word")]
-public class StopWord
+public class StopWord : WordBase
 {
-    [Column("id")]
-    public int Id { get; set; }
-
-    [Column("word")]
-    public required string Word { get; set; } = string.Empty;
-
-    [Column("match_type_id")]
-    public int MatchTypeId { get; set; } = 1;
-    public WordMatchType MatchType { get; set; } = null!;
-
     public ICollection<BaseOrderStopWord> BaseOrderStopWords { get; set; } = new List<BaseOrderStopWord>();
 }

--- a/Logibooks.Core/Models/WordBase.cs
+++ b/Logibooks.Core/Models/WordBase.cs
@@ -12,27 +12,31 @@
 // documentation and/or other materials provided with the distribution.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 // PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
 // BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 // CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Logibooks.Core.Models;
 
-[Table("key_words")]
-[Index(nameof(Word), IsUnique = true, Name = "IX_key_words_word")]
-public class KeyWord : WordBase
+public abstract class WordBase
 {
-    [Column("feacn_code")]
-    public string FeacnCode { get; set; } = string.Empty;
-    public ICollection<BaseOrderKeyWord> BaseOrderKeyWords { get; set; } = [];
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("word")]
+    public required string Word { get; set; } = string.Empty;
+
+    [Column("match_type_id")]
+    public int MatchTypeId { get; set; } = 1;
+    public WordMatchType MatchType { get; set; } = null!;
 }
+


### PR DESCRIPTION
## Summary
- factor out common fields from StopWord and KeyWord into new abstract WordBase
- configure TPC mapping to avoid base table
- update StopWord and KeyWord to inherit from WordBase

## Testing
- `dotnet build Logibooks.sln`
- `dotnet test Logibooks.sln`
- `dotnet ef migrations add WordBaseTest --project Logibooks.Core --startup-project Logibooks.Core` (temporary migration to ensure no table creation)


------
https://chatgpt.com/codex/tasks/task_e_68a05ea4e2088321970b9d76245ea860