### PR TITLE
refactor: move word lookup context

### DIFF
--- a/Logibooks.Core.Tests/Controllers/Parcels/ParcelsControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/Parcels/ParcelsControllerTests.cs
@@ -805,7 +805,7 @@ public class ParcelsControllerTests
         _mockValidationService.Verify(s => s.ValidateAsync(
             order,
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Once);
@@ -821,7 +821,7 @@ public class ParcelsControllerTests
         _mockValidationService.Verify(s => s.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
@@ -842,7 +842,7 @@ public class ParcelsControllerTests
         _mockValidationService.Verify(s => s.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
@@ -866,7 +866,7 @@ public class ParcelsControllerTests
         _mockValidationService.Verify(s => s.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);

--- a/Logibooks.Core.Tests/Services/RegisterValidationServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/RegisterValidationServiceTests.cs
@@ -80,7 +80,7 @@ public class RegisterValidationServiceTests
         mock.Setup(m => m.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(), 
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -99,7 +99,7 @@ public class RegisterValidationServiceTests
         mock.Verify(m => m.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(), 
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Exactly(2));
@@ -120,7 +120,7 @@ public class RegisterValidationServiceTests
         mock.Setup(m => m.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()))
             .Returns(async () => { await Task.Delay(20); tcs.TrySetResult(); });
@@ -281,7 +281,7 @@ public class RegisterValidationServiceTests
         mock.Setup(m => m.ValidateAsync(
             It.IsAny<BaseOrder>(),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -295,28 +295,28 @@ public class RegisterValidationServiceTests
         mock.Verify(m => m.ValidateAsync(
             It.Is<BaseOrder>(o => o.Id == 201),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Once);
         mock.Verify(m => m.ValidateAsync(
             It.Is<BaseOrder>(o => o.Id == 202),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
         mock.Verify(m => m.ValidateAsync(
             It.Is<BaseOrder>(o => o.Id == 203),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
         mock.Verify(m => m.ValidateAsync(
             It.Is<BaseOrder>(o => o.Id == 204),
             It.IsAny<MorphologyContext>(),
-            It.IsAny<WordsLookupContext>(),
+            It.IsAny<WordsLookupContext<StopWord>>(),
             It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);

--- a/Logibooks.Core.Tests/Services/WordsLookupContextTests.cs
+++ b/Logibooks.Core.Tests/Services/WordsLookupContextTests.cs
@@ -28,8 +28,6 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Logibooks.Core.Models;
-using Logibooks.Core.Services;
-using Logibooks.Core.Interfaces;
 
 namespace Logibooks.Core.Tests.Services;
 
@@ -46,16 +44,13 @@ public class WordsLookupContextTests
 
     private static List<StopWord> AllStopWords => new() { swSymbols1, swSymbols2, swWord1, swWord2, swWord3, swPhrase1, swPhrase2 };
 
-    private static WordsLookupContext CreateContext() =>
-        new ParcelValidationService(null!, null!, null!).InitializeWordsLookupContext(AllStopWords);
+    private static WordsLookupContext<StopWord> CreateContext() =>
+        new WordsLookupContext<StopWord>(AllStopWords);
 
     private static List<StopWord> Match(string productName)
     {
         var context = CreateContext();
-        var method = typeof(ParcelValidationService)
-            .GetMethod("GetMatchingStopWordsFromContext", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        var temp = method?.Invoke(null, [productName, context]);
-        return temp is not null ? (List<StopWord>)temp : [];
+        return context.GetMatchingWords(productName).ToList();
     }
 
     [Test]

--- a/Logibooks.Core/Controllers/ParcelsController.cs
+++ b/Logibooks.Core/Controllers/ParcelsController.cs
@@ -465,7 +465,7 @@ public class ParcelsController(
         var stopWords = await _db.StopWords.AsNoTracking().ToListAsync();
         var morphologyContext = _morphologyService.InitializeContext(
             stopWords.Where(sw => sw.MatchTypeId >= (int)WordMatchTypeCode.MorphologyMatchTypes));
-        var wordsLookupContext = _validationService.InitializeWordsLookupContext(
+        var wordsLookupContext = new WordsLookupContext<StopWord>(
             stopWords.Where(sw => sw.MatchTypeId < (int)WordMatchTypeCode.MorphologyMatchTypes));
 
         await _validationService.ValidateAsync(order, morphologyContext, wordsLookupContext, null);

--- a/Logibooks.Core/Interfaces/IParcelValidationService.cs
+++ b/Logibooks.Core/Interfaces/IParcelValidationService.cs
@@ -25,7 +25,6 @@
 
 using Logibooks.Core.Models;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 [assembly: InternalsVisibleTo("Logibooks.Core.Tests")]
 
 namespace Logibooks.Core.Interfaces;
@@ -34,16 +33,7 @@ public interface IParcelValidationService
 {
     Task ValidateAsync(BaseOrder order,
         MorphologyContext morphologyContext,
-        WordsLookupContext wordsLookupContext,
+        WordsLookupContext<StopWord> wordsLookupContext,
         FeacnPrefixCheckContext? feacnContext = null,
         CancellationToken cancellationToken = default);
-
-    WordsLookupContext InitializeWordsLookupContext(IEnumerable<StopWord> exactMatchStopWords);
-}
-
-public class WordsLookupContext
-{
-    internal List<StopWord> ExactSymbolsMatchItems { get; } = [];
-    internal List<(StopWord sw, Regex regex)> ExactWordRegexes { get; } = [];
-    internal List<(StopWord sw, Regex regex)> PhraseRegexes { get; } = [];
 }

--- a/Logibooks.Core/Models/WordsLookupContext.cs
+++ b/Logibooks.Core/Models/WordsLookupContext.cs
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Logibooks.Core.Models;
+
+public class WordsLookupContext<TWord> where TWord : WordBase
+{
+    internal List<TWord> ExactSymbolsMatchItems { get; } = [];
+    internal List<(TWord word, Regex regex)> ExactWordRegexes { get; } = [];
+    internal List<(TWord word, Regex regex)> PhraseRegexes { get; } = [];
+
+    public WordsLookupContext(IEnumerable<TWord> words)
+    {
+        List<TWord> exactWordMatchItems = [];
+        List<TWord> phraseMatchItems = [];
+
+        var filtered = words
+            .Where(sw => sw.MatchTypeId < (int)WordMatchTypeCode.MorphologyMatchTypes);
+
+        var grouped = filtered
+            .GroupBy(sw => (WordMatchTypeCode)sw.MatchTypeId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        ExactSymbolsMatchItems.AddRange(
+            grouped.TryGetValue(WordMatchTypeCode.ExactSymbols, out var symbols) ? symbols : []);
+        exactWordMatchItems.AddRange(
+            grouped.TryGetValue(WordMatchTypeCode.ExactWord, out var wordsGroup) ? wordsGroup : []);
+        phraseMatchItems.AddRange(
+            grouped.TryGetValue(WordMatchTypeCode.Phrase, out var phrases) ? phrases : []);
+
+        foreach (var sw in exactWordMatchItems)
+        {
+            if (!string.IsNullOrEmpty(sw.Word))
+            {
+                var regex = new Regex($@"(?<=^|[^\w-]){Regex.Escape(sw.Word.Trim())}(?=[^\w-]|$)",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                ExactWordRegexes.Add((sw, regex));
+            }
+        }
+
+        foreach (var sw in phraseMatchItems)
+        {
+            if (!string.IsNullOrWhiteSpace(sw.Word))
+            {
+                var phraseWords = Regex.Split(sw.Word.Trim(), "[^\\w-]+", RegexOptions.Compiled)
+                    .Where(w => !string.IsNullOrWhiteSpace(w))
+                    .ToArray();
+                if (phraseWords.Length > 0)
+                {
+                    var pattern = string.Join("[^\\w-]+", phraseWords.Select(w => $"{Regex.Escape(w)}"));
+                    var phraseRegex = new Regex(@$"(?<=^|[^\w-]){pattern}(?=[^\w-]|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                    PhraseRegexes.Add((sw, phraseRegex));
+                }
+            }
+        }
+    }
+
+    public IEnumerable<TWord> GetMatchingWords(string productName)
+    {
+        var result = new List<TWord>();
+
+        result.AddRange(ExactSymbolsMatchItems
+            .Where(sw => !string.IsNullOrEmpty(sw.Word) &&
+                         productName.Contains(sw.Word, StringComparison.OrdinalIgnoreCase)));
+
+        foreach (var pair in ExactWordRegexes)
+        {
+            if (pair.regex.IsMatch(productName))
+                result.Add(pair.word);
+        }
+
+        foreach (var pair in PhraseRegexes)
+        {
+            if (pair.regex.IsMatch(productName))
+                result.Add(pair.word);
+        }
+
+        return result;
+    }
+}
+

--- a/Logibooks.Core/Services/RegisterValidationService.cs
+++ b/Logibooks.Core/Services/RegisterValidationService.cs
@@ -104,7 +104,7 @@ public class RegisterValidationService(
                 process.Total = orders.Count;
                 tcs.TrySetResult();
 
-                var stopWordsContext = scopedOrderSvc.InitializeWordsLookupContext(allStopWords);
+                var stopWordsContext = new WordsLookupContext<StopWord>(allStopWords);
                 var feacnContext = await scopedFeacnSvc.CreateContext(process.Cts.Token);
 
                 foreach (var id in orders)


### PR DESCRIPTION
## Summary
- introduce generic `WordsLookupContext<TWord>` for regex-based matching
- refactor parcel validation to use the new context directly
- adjust services, controllers, and tests for streamlined initialization

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj --no-build --filter FullyQualifiedName~WordsLookupContextTests`


------
https://chatgpt.com/codex/tasks/task_e_68a076dec0148321b1ef507a7d16a509