### PR TITLE
Add ParcelFeacnCodeLookupService

### DIFF
--- a/Logibooks.Core.Tests/Services/ParcelFeacnCodeLookupServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/ParcelFeacnCodeLookupServiceTests.cs
@@ -1,0 +1,146 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.Services;
+using Logibooks.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Logibooks.Core.Tests.Services;
+
+[TestFixture]
+public class ParcelFeacnCodeLookupServiceTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"pfcls_{System.Guid.NewGuid()}")
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    [Test]
+    public async Task LookupAsync_AddsLinksAndRemovesExisting()
+    {
+        using var ctx = CreateContext();
+        var order = new WbrOrder { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "This is SPAM" };
+        ctx.Orders.Add(order);
+        ctx.KeyWords.AddRange(
+            new KeyWord { Id = 2, Word = "spam", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols, FeacnCode = "1" },
+            new KeyWord { Id = 3, Word = "other", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols, FeacnCode = "2" }
+        );
+        ctx.Set<BaseOrderKeyWord>().Add(new BaseOrderKeyWord { BaseOrderId = 1, KeyWordId = 99 });
+        await ctx.SaveChangesAsync();
+
+        var svc = new ParcelFeacnCodeLookupService(ctx, new MorphologySearchService());
+        var wordsLookupContext = new WordsLookupContext<KeyWord>(ctx.KeyWords.ToList());
+        var morphologyContext = new MorphologyContext();
+        await svc.LookupAsync(order, morphologyContext, wordsLookupContext);
+
+        var links = ctx.Set<BaseOrderKeyWord>().ToList();
+        Assert.That(links.Count, Is.EqualTo(1));
+        Assert.That(links.Single().KeyWordId, Is.EqualTo(2));
+        Assert.That(ctx.Orders.Find(1)!.CheckStatusId, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task LookupAsync_NoMatch_DoesNothing()
+    {
+        using var ctx = CreateContext();
+        var order = new WbrOrder { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "clean" };
+        ctx.Orders.Add(order);
+        ctx.KeyWords.Add(new KeyWord { Id = 2, Word = "spam", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols, FeacnCode = "1" });
+        await ctx.SaveChangesAsync();
+
+        var svc = new ParcelFeacnCodeLookupService(ctx, new MorphologySearchService());
+        var wordsLookupContext = new WordsLookupContext<KeyWord>(ctx.KeyWords.ToList());
+        var morphologyContext = new MorphologyContext();
+        await svc.LookupAsync(order, morphologyContext, wordsLookupContext);
+
+        Assert.That(ctx.Set<BaseOrderKeyWord>().Any(), Is.False);
+        Assert.That(ctx.Orders.Find(1)!.CheckStatusId, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task LookupAsync_MixedKeywords_BothExactAndMorphology()
+    {
+        using var ctx = CreateContext();
+        var order = new WbrOrder { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "This is SPAM with золотой браслет" };
+        ctx.Orders.Add(order);
+
+        var keywords = new[]
+        {
+            new KeyWord { Id = 10, Word = "spam", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols, FeacnCode = "1" },
+            new KeyWord { Id = 20, Word = "золото", MatchTypeId = (int)WordMatchTypeCode.StrongMorphology, FeacnCode = "2" }
+        };
+        ctx.KeyWords.AddRange(keywords);
+        await ctx.SaveChangesAsync();
+
+        var morph = new MorphologySearchService();
+        var morphologyContext = morph.InitializeContext(keywords
+            .Where(k => k.MatchTypeId >= (int)WordMatchTypeCode.MorphologyMatchTypes)
+            .Select(k => new StopWord { Id = k.Id, Word = k.Word, MatchTypeId = k.MatchTypeId }));
+        var wordsLookupContext = new WordsLookupContext<KeyWord>(keywords.Where(k => k.MatchTypeId == (int)WordMatchTypeCode.ExactSymbols));
+        var svc = new ParcelFeacnCodeLookupService(ctx, morph);
+        await svc.LookupAsync(order, morphologyContext, wordsLookupContext);
+
+        var links = ctx.Set<BaseOrderKeyWord>().ToList();
+        var foundIds = links.Select(l => l.KeyWordId).OrderBy(id => id).ToList();
+
+        Assert.That(links.Count, Is.EqualTo(2));
+        Assert.That(foundIds, Is.EquivalentTo(new[] { 10, 20 }));
+    }
+
+    [Test]
+    public async Task LookupAsync_SkipsMarkedByPartner()
+    {
+        using var ctx = CreateContext();
+        var order = new WbrOrder
+        {
+            Id = 1,
+            RegisterId = 1,
+            CheckStatusId = (int)ParcelCheckStatusCode.MarkedByPartner,
+            ProductName = "spam"
+        };
+        ctx.Orders.Add(order);
+        ctx.KeyWords.Add(new KeyWord { Id = 2, Word = "spam", MatchTypeId = (int)WordMatchTypeCode.ExactSymbols, FeacnCode = "1" });
+        ctx.Set<BaseOrderKeyWord>().Add(new BaseOrderKeyWord { BaseOrderId = 1, KeyWordId = 99 });
+        await ctx.SaveChangesAsync();
+
+        var svc = new ParcelFeacnCodeLookupService(ctx, new MorphologySearchService());
+        var wordsLookupContext = new WordsLookupContext<KeyWord>(ctx.KeyWords.ToList());
+        var morphologyContext = new MorphologyContext();
+        await svc.LookupAsync(order, morphologyContext, wordsLookupContext);
+
+        var links = ctx.Set<BaseOrderKeyWord>().ToList();
+        Assert.That(links.Count, Is.EqualTo(1));
+        Assert.That(links.Single().KeyWordId, Is.EqualTo(99));
+        Assert.That(ctx.Orders.Find(1)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.MarkedByPartner));
+    }
+}

--- a/Logibooks.Core/Interfaces/IParcelFeacnCodeLookupService.cs
+++ b/Logibooks.Core/Interfaces/IParcelFeacnCodeLookupService.cs
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Logibooks.Core.Models;
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Logibooks.Core.Tests")]
+
+namespace Logibooks.Core.Interfaces;
+
+public interface IParcelFeacnCodeLookupService
+{
+    Task LookupAsync(BaseOrder order,
+        MorphologyContext morphologyContext,
+        WordsLookupContext<KeyWord> wordsLookupContext,
+        CancellationToken cancellationToken = default);
+}

--- a/Logibooks.Core/Program.cs
+++ b/Logibooks.Core/Program.cs
@@ -58,6 +58,7 @@ builder.Services
     .AddScoped<IUpdateFeacnCodesService, UpdateFeacnCodesService>()
     .AddScoped<IFeacnPrefixCheckService, FeacnPrefixCheckService>()
     .AddScoped<IParcelValidationService, ParcelValidationService>()
+    .AddScoped<IParcelFeacnCodeLookupService, ParcelFeacnCodeLookupService>()
     .AddScoped<IRegisterValidationService, RegisterValidationService>()
     .AddScoped<IRegisterProcessingService, RegisterProcessingService>()
     .AddScoped<IKeywordsProcessingService, KeywordsProcessingService>()

--- a/Logibooks.Core/Services/ParcelFeacnCodeLookupService.cs
+++ b/Logibooks.Core/Services/ParcelFeacnCodeLookupService.cs
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE),
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Logibooks.Core.Data;
+using Logibooks.Core.Interfaces;
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.Services;
+
+public class ParcelFeacnCodeLookupService(
+    AppDbContext db,
+    IMorphologySearchService morphService) : IParcelFeacnCodeLookupService
+{
+    private readonly AppDbContext _db = db;
+    private readonly IMorphologySearchService _morphService = morphService;
+
+    public async Task LookupAsync(
+        BaseOrder order,
+        MorphologyContext morphologyContext,
+        WordsLookupContext<KeyWord> wordsLookupContext,
+        CancellationToken cancellationToken = default)
+    {
+        if (order.CheckStatusId == (int)ParcelCheckStatusCode.MarkedByPartner)
+        {
+            return;
+        }
+
+        var existing = _db.Set<BaseOrderKeyWord>().Where(l => l.BaseOrderId == order.Id);
+        _db.Set<BaseOrderKeyWord>().RemoveRange(existing);
+
+        var productName = order.ProductName ?? string.Empty;
+        var links = SelectKeyWordLinks(order.Id, productName, wordsLookupContext, morphologyContext);
+
+        if (order is WbrOrder wbr && !string.IsNullOrWhiteSpace(wbr.Description))
+        {
+            var linksDesc = SelectKeyWordLinks(order.Id, wbr.Description, wordsLookupContext, morphologyContext);
+            var existingIds = new HashSet<int>(links.Select(l => l.KeyWordId));
+            foreach (var link in linksDesc)
+            {
+                if (existingIds.Add(link.KeyWordId))
+                {
+                    links.Add(link);
+                }
+            }
+        }
+
+        if (links.Count > 0)
+        {
+            _db.AddRange(links);
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    private List<BaseOrderKeyWord> SelectKeyWordLinks(
+        int orderId,
+        string text,
+        WordsLookupContext<KeyWord> wordsLookupContext,
+        MorphologyContext morphologyContext)
+    {
+        var links = new List<BaseOrderKeyWord>();
+        var existingKeyWordIds = new HashSet<int>();
+
+        var matchingWords = wordsLookupContext.GetMatchingWords(text);
+
+        foreach (var kw in matchingWords)
+        {
+            links.Add(new BaseOrderKeyWord { BaseOrderId = orderId, KeyWordId = kw.Id });
+            existingKeyWordIds.Add(kw.Id);
+        }
+
+        var ids = _morphService.CheckText(morphologyContext, text);
+        foreach (var id in ids)
+        {
+            if (existingKeyWordIds.Add(id))
+            {
+                links.Add(new BaseOrderKeyWord { BaseOrderId = orderId, KeyWordId = id });
+            }
+        }
+
+        return links;
+    }
+}


### PR DESCRIPTION
## Summary
- add parcel FEACN code lookup service using keywords and morphology
- register ParcelFeacnCodeLookupService in dependency injection
- cover keyword lookup logic with tests

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a08b6e37848321bee4c0b7ec402651