### PR TITLE
Add FEACN code lookup endpoint

### DIFF
--- a/Logibooks.Core.Tests/Controllers/Parcels/ParcelsControllerSortingTests.cs
+++ b/Logibooks.Core.Tests/Controllers/Parcels/ParcelsControllerSortingTests.cs
@@ -51,6 +51,7 @@ public class ParcelsControllerSortingTests
     private AppDbContext _dbContext;
     private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private Mock<IParcelValidationService> _mockValidationService;
+    private Mock<IParcelFeacnCodeLookupService> _mockFeacnLookupService;
     private IMorphologySearchService _morphologyService;
     private Mock<IRegisterProcessingService> _mockProcessingService;
     private Mock<IParcelIndPostGenerator> _mockIndPostGenerator;
@@ -69,7 +70,7 @@ public class ParcelsControllerSortingTests
         _dbContext = new AppDbContext(options);
 
         // Add roles and users
-        var logistRole = new Role { Id = 1, Name = "logist", Title = "Ëîãèñò" };
+        var logistRole = new Role { Id = 1, Name = "logist", Title = "Ã‹Ã®Ã£Ã¨Ã±Ã²" };
         _dbContext.Roles.Add(logistRole);
 
         string hpw = BCrypt.Net.BCrypt.HashPassword("pwd");
@@ -95,6 +96,7 @@ public class ParcelsControllerSortingTests
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _logger = new LoggerFactory().CreateLogger<ParcelsController>();
         _mockValidationService = new Mock<IParcelValidationService>();
+        _mockFeacnLookupService = new Mock<IParcelFeacnCodeLookupService>();
         _mockProcessingService = new Mock<IRegisterProcessingService>();
         _mockIndPostGenerator = new Mock<IParcelIndPostGenerator>();
         _morphologyService = new MorphologySearchService();
@@ -119,6 +121,7 @@ public class ParcelsControllerSortingTests
             _logger,
             mockMapper.Object,
             _mockValidationService.Object,
+            _mockFeacnLookupService.Object,
             _morphologyService,
             _mockProcessingService.Object,
             _mockIndPostGenerator.Object);


### PR DESCRIPTION
## Summary
- add `lookup-feacn-code` endpoint to ParcelsController using `ParcelFeacnCodeLookupService`
- populate FEACN keyword links without FeacnPrefix checks
- cover keyword lookup with unit tests

## Testing
- `dotnet test Logibooks.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a091eeb3488321b79c4cc28e1db7bd