### PR TITLE
Add register FEACN code lookup endpoints

### DIFF
--- a/Logibooks.Core.Tests/Controllers/Registers/RegistersControllerTestsBase.cs
+++ b/Logibooks.Core.Tests/Controllers/Registers/RegistersControllerTestsBase.cs
@@ -49,6 +49,7 @@ public abstract class RegistersControllerTestsBase
     protected AppDbContext _dbContext;
     protected Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     protected Mock<IRegisterValidationService> _mockRegValidationService;
+    protected Mock<IRegisterFeacnCodeLookupService> _mockRegFeacnLookupService;
     protected ILogger<RegistersController> _logger;
     protected IUserInformationService _userService;
     protected Role _logistRole;
@@ -153,11 +154,12 @@ public abstract class RegistersControllerTestsBase
 
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockRegValidationService = new Mock<IRegisterValidationService>();
+        _mockRegFeacnLookupService = new Mock<IRegisterFeacnCodeLookupService>();
         _mockProcessingService = new Mock<IRegisterProcessingService>();
         _mockIndPostGenerator = new Mock<IParcelIndPostGenerator>();
         _logger = new LoggerFactory().CreateLogger<RegistersController>();
         _userService = new UserInformationService(_dbContext);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockRegFeacnLookupService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     [TearDown]
@@ -172,7 +174,7 @@ public abstract class RegistersControllerTestsBase
         var ctx = new DefaultHttpContext();
         ctx.Items["UserId"] = id;
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
-        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
+        _controller = new RegistersController(_mockHttpContextAccessor.Object, _dbContext, _userService, _logger, _mockRegValidationService.Object, _mockRegFeacnLookupService.Object, _mockProcessingService.Object, _mockIndPostGenerator.Object);
     }
 
     protected static Mock<IFormFile> CreateMockFile(string fileName, string contentType, byte[] content)


### PR DESCRIPTION
## Summary
- add `lookup-feacn-codes` POST/GET/DELETE endpoints to `RegistersController`
- inject `IRegisterFeacnCodeLookupService` for register-wide keyword lookup
- extend tests to cover FEACN lookup behavior and keyword link creation

## Testing
- `dotnet test Logibooks.Core.Tests/Logibooks.Core.Tests.csproj --filter "FullyQualifiedName~RegistersControllerTests"` *(fails: test run exited before reporting results)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a191970c8321aff23328f6017a0c