### PR TITLE
Add FEACN codes controller and DTO

### DIFF
--- a/Logibooks.Core.Tests/Controllers/FeacnCodesControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/FeacnCodesControllerTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using Logibooks.Core.Controllers;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.Tests.Controllers;
+
+[TestFixture]
+public class FeacnCodesControllerTests
+{
+#pragma warning disable CS8618
+    private AppDbContext _dbContext;
+    private Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+    private ILogger<FeacnCodesController> _logger;
+    private FeacnCodesController _controller;
+    private Role _userRole;
+    private User _user;
+#pragma warning restore CS8618
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"feacncodes_controller_db_{Guid.NewGuid()}")
+            .Options;
+        _dbContext = new AppDbContext(options);
+
+        _userRole = new Role { Id = 1, Name = "user", Title = "User" };
+        _dbContext.Roles.Add(_userRole);
+        string hpw = BCrypt.Net.BCrypt.HashPassword("pwd");
+        _user = new User
+        {
+            Id = 1,
+            Email = "user@example.com",
+            Password = hpw,
+            UserRoles = [ new UserRole { UserId = 1, RoleId = 1, Role = _userRole } ]
+        };
+        _dbContext.Users.Add(_user);
+        _dbContext.SaveChanges();
+
+        _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        _logger = new LoggerFactory().CreateLogger<FeacnCodesController>();
+        _controller = new FeacnCodesController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dbContext.Database.EnsureDeleted();
+        _dbContext.Dispose();
+    }
+
+    private void SetCurrentUserId(int id)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Items["UserId"] = id;
+        _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(ctx);
+        _controller = new FeacnCodesController(_mockHttpContextAccessor.Object, _dbContext, _logger);
+    }
+
+    [Test]
+    public async Task Get_ReturnsDto_WhenExists()
+    {
+        SetCurrentUserId(1);
+        var code = new FeacnCode { Id = 10, Code = "1234567890", CodeEx = "1234567890", Name = "Name", NormalizedName = "NAME" };
+        _dbContext.FeacnCodes.Add(code);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Get(10);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Id, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task Get_ReturnsNotFound_WhenMissing()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.Get(999);
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task GetByCode_ReturnsBadRequest_OnInvalidCode()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.GetByCode("123");
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+    }
+
+    [Test]
+    public async Task GetByCode_ReturnsNotFound_WhenMissing()
+    {
+        SetCurrentUserId(1);
+        var result = await _controller.GetByCode("1234567890");
+        Assert.That(result.Result, Is.TypeOf<ObjectResult>());
+        var obj = result.Result as ObjectResult;
+        Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
+    }
+
+    [Test]
+    public async Task GetByCode_ReturnsDto_WhenExists()
+    {
+        SetCurrentUserId(1);
+        var code = new FeacnCode { Id = 20, Code = "1234567890", CodeEx = "1234567890", Name = "N1", NormalizedName = "N1" };
+        _dbContext.FeacnCodes.Add(code);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.GetByCode("1234567890");
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Code, Is.EqualTo("1234567890"));
+    }
+
+    [Test]
+    public async Task Lookup_ReturnsMatchingCodes()
+    {
+        SetCurrentUserId(1);
+        _dbContext.FeacnCodes.AddRange(
+            new FeacnCode { Id = 1, Code = "1111111111", CodeEx = "1111111111", Name = "A", NormalizedName = "ABC", FromDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)) },
+            new FeacnCode { Id = 2, Code = "2222222222", CodeEx = "2222222222", Name = "B", NormalizedName = "XYZ", FromDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)) },
+            new FeacnCode { Id = 3, Code = "3333333333", CodeEx = "3333333333", Name = "C", NormalizedName = "ABC", FromDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)) }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Lookup("abc");
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(1));
+        Assert.That(result.Value!.First().Code, Is.EqualTo("1111111111"));
+    }
+
+    [Test]
+    public async Task Children_ReturnsTopLevel_WhenIdNull()
+    {
+        SetCurrentUserId(1);
+        _dbContext.FeacnCodes.AddRange(
+            new FeacnCode { Id = 1, Code = "1111111111", CodeEx = "1111111111", Name = "root", NormalizedName = "ROOT" },
+            new FeacnCode { Id = 2, Code = "2222222222", CodeEx = "2222222222", Name = "child", NormalizedName = "CHILD", ParentId = 1 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Children(null);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(1));
+        Assert.That(result.Value!.First().Id, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Children_ReturnsChildren_ForGivenId()
+    {
+        SetCurrentUserId(1);
+        _dbContext.FeacnCodes.AddRange(
+            new FeacnCode { Id = 1, Code = "1111111111", CodeEx = "1111111111", Name = "root", NormalizedName = "ROOT" },
+            new FeacnCode { Id = 2, Code = "2222222222", CodeEx = "2222222222", Name = "child1", NormalizedName = "CHILD1", ParentId = 1 },
+            new FeacnCode { Id = 3, Code = "3333333333", CodeEx = "3333333333", Name = "child2", NormalizedName = "CHILD2", ParentId = 1 }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _controller.Children(1);
+
+        Assert.That(result.Value, Is.Not.Null);
+        Assert.That(result.Value!.Count(), Is.EqualTo(2));
+    }
+}

--- a/Logibooks.Core/Controllers/FeacnCodesController.cs
+++ b/Logibooks.Core/Controllers/FeacnCodesController.cs
@@ -1,0 +1,101 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+using Logibooks.Core.Authorization;
+using Logibooks.Core.Data;
+using Logibooks.Core.Models;
+using Logibooks.Core.RestModels;
+
+namespace Logibooks.Core.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ErrMessage))]
+[ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrMessage))]
+public class FeacnCodesController(
+    IHttpContextAccessor httpContextAccessor,
+    AppDbContext db,
+    ILogger<FeacnCodesController> logger) : LogibooksControllerBase(httpContextAccessor, db, logger)
+{
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FeacnCodeDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<FeacnCodeDto>> Get(int id)
+    {
+        var code = await _db.FeacnCodes.AsNoTracking().FirstOrDefaultAsync(c => c.Id == id);
+        return code == null ? _404Object(id) : new FeacnCodeDto(code);
+    }
+
+    [HttpGet("code/{code}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FeacnCodeDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ErrMessage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrMessage))]
+    public async Task<ActionResult<FeacnCodeDto>> GetByCode(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code) ||
+            code.Length != FeacnCode.FeacnCodeLength ||
+            !code.All(char.IsDigit))
+        {
+            return _400MustBe10Digits(code);
+        }
+
+        var fc = await _db.FeacnCodes.AsNoTracking().FirstOrDefaultAsync(c => c.Code == code);
+        return fc == null ? _404FeacnCode(code) : new FeacnCodeDto(fc);
+    }
+
+    [HttpGet("lookup/{key}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<FeacnCodeDto>))]
+    public async Task<ActionResult<IEnumerable<FeacnCodeDto>>> Lookup(string key)
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var upperKey = key.ToUpper();
+        var codes = await _db.FeacnCodes.AsNoTracking()
+            .Where(c => (c.FromDate == null || c.FromDate <= today) &&
+                        c.NormalizedName.Contains(upperKey))
+            .OrderBy(c => c.Id)
+            .Select(c => new FeacnCodeDto(c))
+            .ToListAsync();
+        return codes;
+    }
+
+    [HttpGet("children")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<FeacnCodeDto>))]
+    public async Task<ActionResult<IEnumerable<FeacnCodeDto>>> Children(int? id)
+    {
+        IQueryable<FeacnCode> query = _db.FeacnCodes.AsNoTracking();
+        query = id.HasValue ? query.Where(c => c.ParentId == id.Value) : query.Where(c => c.ParentId == null);
+        var codes = await query
+            .OrderBy(c => c.Id)
+            .Select(c => new FeacnCodeDto(c))
+            .ToListAsync();
+        return codes;
+    }
+}
+

--- a/Logibooks.Core/Controllers/LogibooksControllerBase.cs
+++ b/Logibooks.Core/Controllers/LogibooksControllerBase.cs
@@ -177,6 +177,12 @@ public class LogibooksControllerPreBase(AppDbContext db, ILogger logger) : Contr
                           new ErrMessage { Msg = $"Не удалось найти операцию проверки [id={handleId}]" });
     }
 
+    protected ObjectResult _404FeacnCode(string code)
+    {
+        return StatusCode(StatusCodes.Status404NotFound,
+                          new ErrMessage { Msg = $"Не удалось найти код ТН ВЭД [код={code}]" });
+    }
+
     protected ObjectResult _404FeacnOrder(int id)
     {
         return StatusCode(StatusCodes.Status404NotFound,

--- a/Logibooks.Core/RestModels/FeacnCodeDto.cs
+++ b/Logibooks.Core/RestModels/FeacnCodeDto.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Logibooks Core application
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using Logibooks.Core.Models;
+
+namespace Logibooks.Core.RestModels;
+
+public class FeacnCodeDto
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string CodeEx { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string NormalizedName { get; set; } = string.Empty;
+    public int? ParentId { get; set; }
+
+    public FeacnCodeDto()
+    {
+    }
+
+    public FeacnCodeDto(FeacnCode code)
+    {
+        Id = code.Id;
+        Code = code.Code;
+        CodeEx = code.CodeEx;
+        Name = code.Name;
+        NormalizedName = code.NormalizedName;
+        ParentId = code.ParentId;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement FeacnCodesController exposing FEACN code search endpoints
- add FeacnCodeDto to transfer basic FEACN information
- provide standardized error handling for FEACN codes and unit tests covering controller logic

## Testing
- `dotnet test Logibooks.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a780ea93f48321bcd16ff4d032a262