### PR TITLE
Validate FEACN codes in parcel validation

### DIFF
--- a/Logibooks.Core.Tests/Services/ParcelValidationServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/ParcelValidationServiceTests.cs
@@ -275,7 +275,8 @@ public class ParcelValidationServiceTests
             Code = "1234567890",
             CodeEx = "1234567890",
             Name = "name",
-            NormalizedName = "name"
+            NormalizedName = "name",
+            FromDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1)
         });
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, TnVed = "1234567890" };
         ctx.Orders.Add(order);
@@ -287,6 +288,31 @@ public class ParcelValidationServiceTests
         await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
 
         Assert.That(ctx.Orders.Find(1)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.NoIssues));
+    }
+
+    [Test]
+    public async Task ValidateAsync_FutureFeacnDate_SetsStatus()
+    {
+        using var ctx = CreateContext();
+        ctx.FeacnCodes.Add(new FeacnCode
+        {
+            Id = 1,
+            Code = "1234567890",
+            CodeEx = "1234567890",
+            Name = "name",
+            NormalizedName = "name",
+            FromDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(1)
+        });
+        var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, TnVed = "1234567890" };
+        ctx.Orders.Add(order);
+        await ctx.SaveChangesAsync();
+
+        var svc = CreateService(ctx);
+        var wordsLookupContext = new WordsLookupContext<StopWord>(Enumerable.Empty<StopWord>());
+        var morphologyContext = new MorphologyContext();
+        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+
+        Assert.That(ctx.Orders.Find(1)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.NonexistingFeacn));
     }
 
     [Test]

--- a/Logibooks.Core/Services/ParcelValidationService.cs
+++ b/Logibooks.Core/Services/ParcelValidationService.cs
@@ -68,8 +68,9 @@ public class ParcelValidationService(
             return;
         }
 
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
         if (await _db.FeacnCodes.AnyAsync(cancellationToken) &&
-            !await _db.FeacnCodes.AnyAsync(fc => fc.Code == order.TnVed, cancellationToken))
+            !await _db.FeacnCodes.AnyAsync(fc => fc.Code == order.TnVed && (fc.FromDate == null || fc.FromDate <= today), cancellationToken))
         {
             order.CheckStatusId = (int)ParcelCheckStatusCode.NonexistingFeacn;
             await _db.SaveChangesAsync(cancellationToken);

--- a/Logibooks.Core/Services/ParcelValidationService.cs
+++ b/Logibooks.Core/Services/ParcelValidationService.cs
@@ -69,8 +69,11 @@ public class ParcelValidationService(
         }
 
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
-        if (await _db.FeacnCodes.AnyAsync(cancellationToken) &&
-            !await _db.FeacnCodes.AnyAsync(fc => fc.Code == order.TnVed && (fc.FromDate == null || fc.FromDate <= today), cancellationToken))
+        var codeExists = await _db.FeacnCodes.AnyAsync(
+            fc => fc.Code == order.TnVed && (fc.FromDate == null || fc.FromDate <= today),
+            cancellationToken);
+
+        if (!codeExists && await _db.FeacnCodes.AnyAsync(cancellationToken))
         {
             order.CheckStatusId = (int)ParcelCheckStatusCode.NonexistingFeacn;
             await _db.SaveChangesAsync(cancellationToken);

--- a/Logibooks.Core/Services/ParcelValidationService.cs
+++ b/Logibooks.Core/Services/ParcelValidationService.cs
@@ -26,6 +26,7 @@
 using Logibooks.Core.Data;
 using Logibooks.Core.Interfaces;
 using Logibooks.Core.Models;
+using Microsoft.EntityFrameworkCore;
 using System.Text.RegularExpressions;
 
 namespace Logibooks.Core.Services;
@@ -63,6 +64,14 @@ public class ParcelValidationService(
         if (string.IsNullOrWhiteSpace(order.TnVed) || !TnVedRegex.IsMatch(order.TnVed))
         {
             order.CheckStatusId = (int)ParcelCheckStatusCode.InvalidFeacnFormat;
+            await _db.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        if (await _db.FeacnCodes.AnyAsync(cancellationToken) &&
+            !await _db.FeacnCodes.AnyAsync(fc => fc.Code == order.TnVed, cancellationToken))
+        {
+            order.CheckStatusId = (int)ParcelCheckStatusCode.NonexistingFeacn;
             await _db.SaveChangesAsync(cancellationToken);
             return;
         }


### PR DESCRIPTION
## Summary
- verify that parcel TN VED values exist in the `FeacnCode` table
- return `NonexistingFeacn` status when code not found
- add tests for existing and missing FEACN codes

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_68a8b42426f48321830f9680b00a0277