### PR TITLE
Split parcel validation into keyword and FEACN checks

### DIFF
--- a/Logibooks.Core.Tests/Controllers/Parcels/ParcelsControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/Parcels/ParcelsControllerTests.cs
@@ -822,11 +822,15 @@ public class ParcelsControllerTests
 
         var result = await _controller.ValidateOrder(10);
 
-        _mockValidationService.Verify(s => s.ValidateAsync(
+        _mockValidationService.Verify(s => s.ValidateFeacnAsync(
+            order,
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockValidationService.Verify(s => s.ValidateKwAsync(
             order,
             It.IsAny<MorphologyContext>(),
             It.IsAny<WordsLookupContext<StopWord>>(),
-            It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Once);
         Assert.That(result, Is.TypeOf<NoContentResult>());
@@ -838,11 +842,15 @@ public class ParcelsControllerTests
         SetCurrentUserId(99);
         var result = await _controller.ValidateOrder(1);
 
-        _mockValidationService.Verify(s => s.ValidateAsync(
+        _mockValidationService.Verify(s => s.ValidateFeacnAsync(
+            It.IsAny<BaseParcel>(),
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockValidationService.Verify(s => s.ValidateKwAsync(
             It.IsAny<BaseParcel>(),
             It.IsAny<MorphologyContext>(),
             It.IsAny<WordsLookupContext<StopWord>>(),
-            It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
         Assert.That(result, Is.TypeOf<ObjectResult>());
@@ -859,11 +867,15 @@ public class ParcelsControllerTests
         Assert.That(result, Is.TypeOf<ObjectResult>());
         var obj = result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
-        _mockValidationService.Verify(s => s.ValidateAsync(
+        _mockValidationService.Verify(s => s.ValidateFeacnAsync(
+            It.IsAny<BaseParcel>(),
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockValidationService.Verify(s => s.ValidateKwAsync(
             It.IsAny<BaseParcel>(),
             It.IsAny<MorphologyContext>(),
             It.IsAny<WordsLookupContext<StopWord>>(),
-            It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -883,11 +895,15 @@ public class ParcelsControllerTests
         Assert.That(result, Is.TypeOf<ObjectResult>());
         var obj = result as ObjectResult;
         Assert.That(obj!.StatusCode, Is.EqualTo(StatusCodes.Status404NotFound));
-        _mockValidationService.Verify(s => s.ValidateAsync(
+        _mockValidationService.Verify(s => s.ValidateFeacnAsync(
+            It.IsAny<BaseParcel>(),
+            It.IsAny<FeacnPrefixCheckContext?>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockValidationService.Verify(s => s.ValidateKwAsync(
             It.IsAny<BaseParcel>(),
             It.IsAny<MorphologyContext>(),
             It.IsAny<WordsLookupContext<StopWord>>(),
-            It.IsAny<FeacnPrefixCheckContext?>(),
             It.IsAny<CancellationToken>()),
             Times.Never);
     }

--- a/Logibooks.Core.Tests/Services/ParcelValidationServiceTests.cs
+++ b/Logibooks.Core.Tests/Services/ParcelValidationServiceTests.cs
@@ -71,7 +71,7 @@ public class ParcelValidationServiceTests
     }
 
     [Test]
-    public async Task ValidateAsync_AddsLinksAndUpdatesStatus()
+    public async Task ValidateKwAsync_AddsLinksAndUpdatesStatus()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "This is SPAM", TnVed = "1234567890" };
@@ -86,7 +86,7 @@ public class ParcelValidationServiceTests
         var svc = CreateService(ctx);
         var wordsLookupContext = new WordsLookupContext<StopWord>(ctx.StopWords.ToList());
         var morphologyContext = new MorphologyContext(); // Assuming you have a way to create this context
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         Assert.That(ctx.Set<BaseParcelStopWord>().Count(), Is.EqualTo(1));
         var link = ctx.Set<BaseParcelStopWord>().Single();
@@ -95,7 +95,7 @@ public class ParcelValidationServiceTests
     }
 
     [Test]
-    public async Task ValidateAsync_NoMatch_DoesNothing()
+    public async Task ValidateKwAsync_NoMatch_DoesNothing()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "clean", TnVed = "1234567890" };
@@ -106,14 +106,14 @@ public class ParcelValidationServiceTests
         var svc = CreateService(ctx);
         var wordsLookupContext = new WordsLookupContext<StopWord>(ctx.StopWords.ToList());
         var morphologyContext = new MorphologyContext(); // Assuming you have a way to create this context
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         Assert.That(ctx.Set<BaseParcelStopWord>().Any(), Is.False);
         Assert.That(ctx.Parcels.Find(1)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.NoIssues));
     }
 
     [Test]
-    public async Task ValidateAsync_IgnoresCase()
+    public async Task ValidateKwAsync_IgnoresCase()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "bad WORD", TnVed = "1234567890" };
@@ -124,14 +124,14 @@ public class ParcelValidationServiceTests
         var svc = CreateService(ctx);
         var wordsLookupContext = new WordsLookupContext<StopWord>(ctx.StopWords.ToList());
         var morphologyContext = new MorphologyContext(); // Assuming you have a way to create this context
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         Assert.That(ctx.Set<BaseParcelStopWord>().Single().StopWordId, Is.EqualTo(5));
         Assert.That(ctx.Parcels.Find(1)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.HasIssues));
     }
 
     [Test]
-    public async Task ValidateAsync_UsesMorphologyContext()
+    public async Task ValidateKwAsync_UsesMorphologyContext()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "золотой браслет", TnVed = "1234567890" };
@@ -144,7 +144,7 @@ public class ParcelValidationServiceTests
         var morphologyContext = morph.InitializeContext(new[] { sw });
         var wordsLookupContext = new WordsLookupContext<StopWord>(Enumerable.Empty<StopWord>());
         var svc = CreateServiceWithMorphology(ctx, morph);
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         var link = ctx.Set<BaseParcelStopWord>().Single();
         Assert.That(link.StopWordId, Is.EqualTo(7));
@@ -152,7 +152,7 @@ public class ParcelValidationServiceTests
     }
 
     [Test]
-    public async Task ValidateAsync_MixedStopWords_BothExactAndMorphology()
+    public async Task ValidateKwAsync_MixedStopWords_BothExactAndMorphology()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "This is SPAM with золотой браслет", TnVed = "1234567890" };
@@ -171,7 +171,7 @@ public class ParcelValidationServiceTests
         var morphologyContext = morph.InitializeContext(stopWords.Where(sw => sw.MatchTypeId >= (int)WordMatchTypeCode.MorphologyMatchTypes));
         var svc = CreateServiceWithMorphology(ctx, morph);
         var wordsLookupContext = new WordsLookupContext<StopWord>(stopWords.Where(sw => sw.MatchTypeId == (int)WordMatchTypeCode.ExactSymbols));
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         var links = ctx.Set<BaseParcelStopWord>().ToList();
         var foundIds = links.Select(l => l.StopWordId).OrderBy(id => id).ToList();
@@ -182,7 +182,7 @@ public class ParcelValidationServiceTests
     }
 
     [Test]
-    public async Task ValidateAsync_RemovesExistingLinksCorrectly()
+    public async Task ValidateKwAsync_RemovesExistingLinksCorrectly()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel { Id = 1, RegisterId = 1, CheckStatusId = 1, ProductName = "SPAM product", TnVed = "1234567890" };
@@ -204,7 +204,7 @@ public class ParcelValidationServiceTests
         var svc = CreateService(ctx);
         var wordsLookupContext = new WordsLookupContext<StopWord>(stopWords);
         var morphologyContext = new MorphologyContext();
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         var links = ctx.Set<BaseParcelStopWord>().ToList();
 
@@ -214,7 +214,7 @@ public class ParcelValidationServiceTests
     }
 
     [Test]
-    public async Task ValidateAsync_SkipsMarkedByPartner()
+    public async Task ValidateKwAsync_SkipsMarkedByPartner()
     {
         using var ctx = CreateContext();
         var order = new WbrParcel
@@ -233,7 +233,7 @@ public class ParcelValidationServiceTests
         var svc = CreateService(ctx);
         var wordsLookupContext = new WordsLookupContext<StopWord>(ctx.StopWords.ToList());
         var morphologyContext = new MorphologyContext();
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         var links = ctx.Set<BaseParcelStopWord>().ToList();
         Assert.That(links.Count, Is.EqualTo(1));
@@ -242,7 +242,7 @@ public class ParcelValidationServiceTests
     }
 
     [Test]
-    public async Task ValidateAsync_ExistingFeacn_ContinuesProcessing()
+    public async Task ValidateFeacnAsync_ExistingFeacn_ContinuesProcessing()
     {
         using var ctx = CreateContext();
         ctx.FeacnCodes.Add(new FeacnCode
@@ -261,9 +261,27 @@ public class ParcelValidationServiceTests
         var svc = CreateService(ctx);
         var wordsLookupContext = new WordsLookupContext<StopWord>(Enumerable.Empty<StopWord>());
         var morphologyContext = new MorphologyContext();
-        await svc.ValidateAsync(order, morphologyContext, wordsLookupContext);
+        await svc.ValidateFeacnAsync(order);
+
+        // ensure keywords validation also keeps status
+        await svc.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
 
         Assert.That(ctx.Parcels.Find(1)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.NoIssues));
+    }
+
+    [Test]
+    public async Task ValidateFeacnAsync_InvalidFormat_SetsStatus()
+    {
+        using var ctx = CreateContext();
+        var order = new WbrParcel { Id = 2, RegisterId = 1, CheckStatusId = 1, TnVed = "bad" };
+        ctx.Parcels.Add(order);
+        await ctx.SaveChangesAsync();
+
+        var svc = CreateService(ctx);
+        await svc.ValidateFeacnAsync(order);
+
+        Assert.That(ctx.Parcels.Find(2)!.CheckStatusId, Is.EqualTo((int)ParcelCheckStatusCode.InvalidFeacnFormat));
+        Assert.That(ctx.Set<BaseParcelFeacnPrefix>().Any(), Is.False);
     }
 
     [Test]

--- a/Logibooks.Core/Controllers/ParcelsController.cs
+++ b/Logibooks.Core/Controllers/ParcelsController.cs
@@ -407,7 +407,11 @@ public class ParcelsController(
         var wordsLookupContext = new WordsLookupContext<StopWord>(
             stopWords.Where(sw => sw.MatchTypeId < (int)WordMatchTypeCode.MorphologyMatchTypes));
 
-        await _validationService.ValidateAsync(order, morphologyContext, wordsLookupContext, null);
+        await _validationService.ValidateFeacnAsync(order, null);
+        if (order.CheckStatusId != (int)ParcelCheckStatusCode.InvalidFeacnFormat)
+        {
+            await _validationService.ValidateKwAsync(order, morphologyContext, wordsLookupContext);
+        }
 
         return NoContent();
     }

--- a/Logibooks.Core/Interfaces/IParcelValidationService.cs
+++ b/Logibooks.Core/Interfaces/IParcelValidationService.cs
@@ -31,9 +31,14 @@ namespace Logibooks.Core.Interfaces;
 
 public interface IParcelValidationService
 {
-    Task ValidateAsync(BaseParcel order,
+    Task ValidateKwAsync(
+        BaseParcel order,
         MorphologyContext morphologyContext,
         WordsLookupContext<StopWord> wordsLookupContext,
+        CancellationToken cancellationToken = default);
+
+    Task ValidateFeacnAsync(
+        BaseParcel order,
         FeacnPrefixCheckContext? feacnContext = null,
         CancellationToken cancellationToken = default);
 }

--- a/Logibooks.Core/Services/RegisterValidationService.cs
+++ b/Logibooks.Core/Services/RegisterValidationService.cs
@@ -117,7 +117,11 @@ public class RegisterValidationService(
                     var order = await scopedDb.Parcels.FindAsync([id], cancellationToken: process.Cts.Token);
                     if (order != null)
                     {
-                        await scopedOrderSvc.ValidateAsync(order, morphologyContext, stopWordsContext, feacnContext, process.Cts.Token);
+                        await scopedOrderSvc.ValidateFeacnAsync(order, feacnContext, process.Cts.Token);
+                        if (order.CheckStatusId != (int)ParcelCheckStatusCode.InvalidFeacnFormat)
+                        {
+                            await scopedOrderSvc.ValidateKwAsync(order, morphologyContext, stopWordsContext, process.Cts.Token);
+                        }
                     }
                     process.Processed++;
                 }


### PR DESCRIPTION
## Summary
- split `ParcelValidationService.ValidateAsync` into `ValidateKwAsync` and `ValidateFeacnAsync`
- validate TN VED format and FEACN prefixes separately from keyword checks
- adjust controllers, register validation flow, and tests for the new API

## Testing
- `dotnet test Logibooks.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b96f62406c8321b9f82eb35377b58e