### PR TITLE
fix: preserve FEACN status on stop-word recheck

### DIFF
--- a/Logibooks.Core.Tests/Controllers/AuthControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/AuthControllerTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core application
+// This file is a part of Logibooks.Core application
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;

--- a/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/StatusControllerTests.cs
@@ -1,6 +1,6 @@
 // Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core application
+// This file is a part of Logibooks.Core application
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/Logibooks.Core.Tests/Controllers/UserControllerTests.cs
+++ b/Logibooks.Core.Tests/Controllers/UserControllerTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core application
+// This file is a part of Logibooks.Core application
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/Logibooks.Core/Controllers/AuthController.cs
+++ b/Logibooks.Core/Controllers/AuthController.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
 // All rights reserved.
-// This file is a part of Logibooks Core application
+// This file is a part of Logibooks.Core application
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/Logibooks.Core/Services/ParcelValidationService.cs
+++ b/Logibooks.Core/Services/ParcelValidationService.cs
@@ -76,6 +76,9 @@ public class ParcelValidationService(
             {((int)ParcelCheckStatusCode.IssueInvalidFeacnFormatAndStopWord, ValidationEvent.StopWordNotFound), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndInvalidFeacnFormat},
             {((int)ParcelCheckStatusCode.IssueNonexistingFeacn, ValidationEvent.StopWordNotFound), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndNonexistingFeacn},
             {((int)ParcelCheckStatusCode.IssueNonexistingFeacnAndStopWord, ValidationEvent.StopWordNotFound), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndNonexistingFeacn},
+            {((int)ParcelCheckStatusCode.NoIssuesStopWordsAndFeacnCode, ValidationEvent.StopWordNotFound), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndFeacnCode},
+            {((int)ParcelCheckStatusCode.NoIssuesStopWordsAndInvalidFeacnFormat, ValidationEvent.StopWordNotFound), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndInvalidFeacnFormat},
+            {((int)ParcelCheckStatusCode.NoIssuesStopWordsAndNonexistingFeacn, ValidationEvent.StopWordNotFound), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndNonexistingFeacn},
 
             // Invalid FEACN format transitions (Запрет)
             {((int)ParcelCheckStatusCode.NoIssues, ValidationEvent.InvalidFeacnFormat), (int)ParcelCheckStatusCode.NoIssuesStopWordsAndInvalidFeacnFormat},


### PR DESCRIPTION
## Summary
- keep FEACN issue status when stop-word revalidation succeeds
- fix project name capitalization in file headers

## Testing
- `dotnet test Logibooks.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bbf6f3d504832196841e46758079b3